### PR TITLE
fix(portal): reinit options list when input is empty

### DIFF
--- a/src/atoms/gv-autocomplete.js
+++ b/src/atoms/gv-autocomplete.js
@@ -180,6 +180,9 @@ export class GvAutocomplete extends LitElement {
         dispatchCustomEvent(this, 'search', this.value);
       }, 200);
     }
+    else {
+      this.options = [];
+    }
   }
 
   _onSelect (value, option) {


### PR DESCRIPTION
Fixes gravitee-io/issues#3470