### PR TITLE
fix(ui-components): words in gv-tag should never be broken

### DIFF
--- a/src/atoms/gv-tag.js
+++ b/src/atoms/gv-tag.js
@@ -121,6 +121,8 @@ export class GvTag extends LitElement {
               padding: 1px 8px;
               --gv-icon--s: var(--gv-tag-icon--s, 18px);
               --gv-icon--c: var(--c);
+
+              word-break: normal;
           }
 
           div > * {


### PR DESCRIPTION
Fixes gravitee-io/issues#3832