### PR TITLE
feat(pictures): delete image

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -40,7 +40,8 @@
       "maxSize": "File size exceeds allowed limit",
       "typeNotAllowed": "This file type is not allowed"
     },
-    "orDragIt": "or drag it here."
+    "orDragIt": "or drag it here.",
+    "removePicture": "Remove picture"
   },
   "gv-header": {
     "empty": "No data to display here",

--- a/assets/i18n/fr.json
+++ b/assets/i18n/fr.json
@@ -40,7 +40,8 @@
       "maxSize": "La taille du fichier dépasse la limite autorisée",
       "typeNotAllowed": "Ce type de fichier n'est pas autorisé"
     },
-    "orDragIt": "ou déposez-le ici."
+    "orDragIt": "ou déposez-le ici.",
+    "removePicture": "Supprimer l'image"
   },
   "gv-header": {
     "empty": "Aucun élément à afficher ici",

--- a/src/atoms/gv-file-upload.js
+++ b/src/atoms/gv-file-upload.js
@@ -317,6 +317,13 @@ export class GvFileUpload extends LitElement {
             <div class="filename">${this._errors[0].file.name} <span class="error">(${this._errors[0].error})</span></div>
         </div>
         ` : ''}
+        ${this.value && this._files.length === 0 && this._errors.length === 0 ? html`
+        <div class="files">
+            <div class="filename"></div>
+            <gv-button link @click="${this._removeFile.bind(this, 0)}">${i18n('gv-file-upload.removePicture')}</gv-button>
+        </div>
+        ` : ''}
+
 `;
   }
 


### PR DESCRIPTION
Add a trash icon when gv-upload is initialize with a value. It is used to delete an existing picture from an object.

Closes gravitee-io/issues#4316