### PR TITLE
fix(components): gv-code should accept 'json' mode for codemirror

### DIFF
--- a/src/molecules/gv-code.js
+++ b/src/molecules/gv-code.js
@@ -102,7 +102,7 @@ export class GvCode extends LitElement {
           color: black;
           direction: ltr;
           margin-top: 0.2rem;
-          
+
         }
 
         /* PADDING */
@@ -806,13 +806,23 @@ export class GvCode extends LitElement {
     });
   }
 
+  _getProcessedOptions () {
+    const options = { ...this.options };
+    if (options.mode === 'json') {
+      options.mode = 'javascript';
+    }
+    return options;
+  }
+
   async updated (changedProperties) {
     if (changedProperties.has('options') && this.options && this.options.mode) {
-      await import(`codemirror/mode/${this.options.mode}/${this.options.mode}`);
+      const options = this._getProcessedOptions();
+
+      await import(`codemirror/mode/${options.mode}/${options.mode}`);
 
       const textArea = this.shadowRoot.querySelector(`#${this._id}`);
       CodeMirror.fromTextArea(textArea, {
-        ...this.options,
+        ...options,
         ...{
           theme: 'mdn-like',
           lineWrapping: true,

--- a/stories/molecules/gv-code.stories.js
+++ b/stories/molecules/gv-code.stories.js
@@ -120,6 +120,24 @@ export const Javascript = makeStory(conf, {
   items: [{ value: jsSrc, options: jsOptions }],
 });
 
+const jsonSrc = `{
+  "id": "foobar",
+  "data": []
+}`;
+
+const jsonOptions = {
+  placeholder: 'Put the body content here',
+  lineNumbers: true,
+  allowDropFileTypes: true,
+  autoCloseBrackets: true,
+  matchBrackets: true,
+  mode: 'json',
+};
+
+export const Json = makeStory(conf, {
+  items: [{ value: jsonSrc, options: jsonOptions }],
+});
+
 const groovySrc = `println 'Hello'                                 
 
 int power(int n) { 2**n }                       

--- a/stories/molecules/gv-code.test.js
+++ b/stories/molecules/gv-code.test.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { Page, querySelector } from '../lib/test-utils';
+import '../../src/molecules/gv-code';
+import { shapeClipboard } from '../../src/styles/shapes';
+
+describe('<gv-code>', () => {
+
+  let page;
+  const DEFAULT_VALUE = 'FOOBAR';
+
+  beforeEach(() => {
+    page = new Page();
+    page.create('gv-code', {
+      value: DEFAULT_VALUE,
+      options: {
+        lineNumbers: true,
+        mode: 'shell',
+      },
+    });
+  });
+
+  afterEach(() => {
+    page.clear();
+  });
+
+  test('should create element', () => {
+    expect(window.customElements.get('gv-code')).toBeDefined();
+    const component = querySelector('gv-code');
+    expect(component).toBeDefined();
+    expect(component.value).toEqual(DEFAULT_VALUE);
+    expect(component.options.lineNumbers).toEqual(true);
+    expect(component.options.mode).toEqual('shell');
+    expect(component.readonly).toEqual(false);
+    expect(component.autofocus).toEqual(false);
+    expect(component.clipboard).toEqual(false);
+    expect(component._clipboardIcon).toEqual(shapeClipboard);
+    expect(component._id).toMatch(/^gv-code-[0-9]{13}$/gm);
+  });
+
+  test('should have initialize textArea', () => {
+    const component = querySelector('gv-code');
+    const textArea = component.shadowRoot.querySelector(`#${component._id}`);
+    expect(textArea).toBeDefined();
+    expect(textArea.innerHTML).toEqual(`<!---->${DEFAULT_VALUE}<!---->`);
+  });
+
+  test('should convert "json" mode to "javascript" mode for CodeMirror compatibility', () => {
+    const component = querySelector('gv-code');
+    // default
+    expect(component._getProcessedOptions().mode).toEqual('shell');
+
+    // with json
+    component.options.mode = 'json';
+    expect(component._getProcessedOptions().mode).toEqual('javascript');
+  });
+});


### PR DESCRIPTION
As codemirror uses 'javascript' mode to render json, gv-code now converts 'json' to 'javascript'

Fixes gravitee-io/issues#4048