### PR TITLE
fix(ui-components): a gv-tag in gv-table cell must not have width: 100%

### DIFF
--- a/src/molecules/gv-table.js
+++ b/src/molecules/gv-table.js
@@ -213,7 +213,7 @@ export class GvTable extends withResizeObserver(LitElement) {
           align-self: flex-end;
         }
 
-        .cell > * {
+        .cell > *:not(gv-tag) {
           margin: auto;
           width: 100%;
         }


### PR DESCRIPTION
fixes gravitee-io/issues#4035
fixes gravitee-io/issues#4461