### PR TITLE
fix: fix error for gv-table documentation

### DIFF
--- a/stories/molecules/gv-table.stories.js
+++ b/stories/molecules/gv-table.stories.js
@@ -183,7 +183,7 @@ export const LoadingAndError = makeStory(conf, {
   ],
 });
 
-export const users = [
+const users = [
   { name: '', _new: true },
   { name: 'me', id: '1' },
   { name: 'someone else', id: '2' },


### PR DESCRIPTION
We have an error when consulting documentation for gv-table in storybook which prevent to load the full page.

You can test the bug here: https://components.gravitee.io/?path=/docs/molecules-gv-table--dynamic-rows