### PR TITLE
Editing gravitee-logo path to be relative

### DIFF
--- a/assets/css/gravitee-theme.generated.css
+++ b/assets/css/gravitee-theme.generated.css
@@ -36,6 +36,6 @@
   --gv-theme-skeleton-color: #BFBFBF;
   --gv-theme-homepage-background-color: #5A7684;
   --gv-theme-homepage-background-image: none;
-  --gv-theme-logo: url('/images/gravitee-logo.png');
-  --gv-theme-optional-logo: url('/images/gravitee-logo-light.png');
+  --gv-theme-logo: url('./images/gravitee-logo.png');
+  --gv-theme-optional-logo: url('./images/gravitee-logo-light.png');
 }


### PR DESCRIPTION
Modify path toward logo to be relative. In case of serving the website behind a reverse proxy, path may be different than '/'. This change make the client correctly generate URL toward logo and logo-light files.