### PR TITLE
fix(gv-gauge): make background transparent

### DIFF
--- a/src/charts/gv-chart-gauge.js
+++ b/src/charts/gv-chart-gauge.js
@@ -47,8 +47,8 @@ export class GvChartGauge extends ChartElement(LitElement) {
     return {
       chart: {
         type: 'solidgauge',
+        backgroundColor: 'transparent',
       },
-
       tooltip: {
         enabled: false,
       },
@@ -59,7 +59,7 @@ export class GvChartGauge extends ChartElement(LitElement) {
         background: [{
           outerRadius: '112%',
           innerRadius: '88%',
-          backgroundColor: '#fff',
+          backgroundColor: 'transparent',
           borderWidth: 0,
         }],
       },

--- a/stories/charts/gv-chart-gauge.stories.js
+++ b/stories/charts/gv-chart-gauge.stories.js
@@ -30,6 +30,11 @@ export default {
 const conf = {
   component: 'gv-chart-gauge',
   events,
+  css: `
+  :host {
+    height: 300px;
+  }
+`,
 };
 
 const series = [{
@@ -53,5 +58,20 @@ const series = [{
 }];
 
 export const Basics = makeStory(conf, {
+  items: [{ series, max: 3 }],
+});
+
+const confWithBackground = {
+  component: 'gv-chart-gauge',
+  events,
+  css: `
+  :host {
+    height: 300px;
+    background: var(--gv-theme-neutral-color, #F5F5F5);
+  }
+`,
+};
+
+export const WithColorfulBackground = makeStory(confWithBackground, {
   items: [{ series, max: 3 }],
 });


### PR DESCRIPTION
### Actual behavior

Gauges have white background. So adding them to a page with a different background color will cause a white rectangle to appear around the gauge
![screenshot-cockpit-nightly cloud gravitee io-2021 01 29-09_34_31](https://user-images.githubusercontent.com/1655950/106251548-639cfc80-6215-11eb-89b9-1905de96a7f5.png)

### Expected behavior

Gauges should have a transparent background