### PR TITLE
Cron Editor: Various small enhancements of design and behavior

### DIFF
--- a/src/molecules/gv-cron-editor.js
+++ b/src/molecules/gv-cron-editor.js
@@ -331,50 +331,54 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
 
   renderProDetails() {
     if (this._state.pro.displayDetails) {
-      return html` <div>
-        <div>Rules for:</div>
-        <div>
-          ${repeat(
-            this._docs,
-            (doc) => doc.id,
-            (doc) => {
-              const isCurrent = doc.id === this._currentDocumentationId;
-              return html`<gv-tag
-                @gv-tag:click="${this._onOpenDocumentation.bind(this, doc.id)}"
-                ?clickable="${!isCurrent}"
-                ?major="${isCurrent}"
-                ?minor="${!isCurrent}"
-                >${doc.label}</gv-tag
-              >`;
-            },
-          )}
+      return html`<div class="tab-content_pro-pane_container">
+        <div class="tab-content_pro-pane">
+          <div>Rules for:</div>
+          <div>
+            ${repeat(
+              this._docs,
+              (doc) => doc.id,
+              (doc) => {
+                const isCurrent = doc.id === this._currentDocumentationId;
+                return html` <gv-tag
+                  @gv-tag:click="${this._onOpenDocumentation.bind(this, doc.id)}"
+                  ?clickable="${!isCurrent}"
+                  ?major="${isCurrent}"
+                  ?minor="${!isCurrent}"
+                  >${doc.label}</gv-tag
+                >`;
+              },
+            )}
+          </div>
+          <ul class="help">
+            <li>
+              <small>Allowed characters: <code>${this.allowedChar}</code></small>
+            </li>
+            <li>
+              <small>Allowed values: <code>${this.allowedValues}</code></small>
+            </li>
+          </ul>
         </div>
-        <ul class="help">
-          <li>
-            <small>Allowed characters: <code>${this.allowedChar}</code></small>
-          </li>
-          <li>
-            <small>Allowed values: <code>${this.allowedValues}</code></small>
-          </li>
-        </ul>
-        <div>Examples:</div>
-        <ul class="help">
-          <li>
-            <small><code>*</code>: for each unit (0, 1, 2, 3...)</small>
-          </li>
-          <li>
-            <small><code>5,8</code>: units 5 and 8</small>
-          </li>
-          <li>
-            <small><code>2-5</code>: units from 2 to 5 (2, 3, 4, 5)</small>
-          </li>
-          <li>
-            <small><code>*/3</code>: every 3 units (0, 3, 6, 9...)</small>
-          </li>
-          <li>
-            <small><code>10-20/3</code>: every 3 units, between the tenth and the twentieth (10, 13, 16, 19)</small>
-          </li>
-        </ul>
+        <div class="tab-content_pro-pane">
+          <div>Examples:</div>
+          <ul class="help">
+            <li>
+              <small><code>*</code>: for each unit (0, 1, 2, 3...)</small>
+            </li>
+            <li>
+              <small><code>5,8</code>: units 5 and 8</small>
+            </li>
+            <li>
+              <small><code>2-5</code>: units from 2 to 5 (2, 3, 4, 5)</small>
+            </li>
+            <li>
+              <small><code>*/3</code>: every 3 units (0, 3, 6, 9...)</small>
+            </li>
+            <li>
+              <small><code>10-20/3</code>: every 3 units, between the tenth and the twentieth (10, 13, 16, 19)</small>
+            </li>
+          </ul>
+        </div>
       </div>`;
     }
 
@@ -625,6 +629,15 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
 
         .tab-content_pro-details_btn {
           --gv-button--fz: 12px;
+        }
+
+        .tab-content_pro-pane_container {
+          display: flex;
+          flex-direction: row;
+        }
+
+        .tab-content_pro-pane {
+          flex: auto;
         }
 
         .tab-content_pro > * {

--- a/src/molecules/gv-cron-editor.js
+++ b/src/molecules/gv-cron-editor.js
@@ -35,7 +35,7 @@ import { dispatchCustomEvent } from '../lib/events';
  *
  * @attr {String} label - cron editor label
  * @attr {String} value - cron expression
- * @attr {String} mode - the opened mode (if have value, the export mode will be open)
+ * @attr {String} mode - the opened mode (if no value is set, the pro mode will be opened)
  *
  * @attr {Boolean} [clipboard=false]- true if field has clipboard button
  * @attr {Boolean} [autofocus=false] - true to put the focus on the input

--- a/src/molecules/gv-cron-editor.js
+++ b/src/molecules/gv-cron-editor.js
@@ -369,7 +369,7 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
           </div>
 
           <div slot="content" id="monthly" class="tab-content">
-            <span>On</span>
+            <span>On the</span>
             <gv-input
               small
               type="number"
@@ -379,7 +379,8 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
               class="request-update"
               .value="${this._state.monthly.day}"
             ></gv-input>
-            <span><sup>${this._getDaySuffix(this._state.monthly.day)}</sup> day of every</span>
+            <span><sup>${this._getDaySuffix(this._state.monthly.day)}</sup> </span>
+            <span>day of every</span>
             <gv-input small type="number" min="1" max="12" name="monthly.month" .value="${this._state.monthly.month}"></gv-input>
             <span>month(s) at</span>
             <gv-date-picker small time strict name="monthly.time" .value="${this._state.monthly.time}"></gv-date-picker>
@@ -398,7 +399,8 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
               class="request-update"
               .value="${this._state.yearly.day}"
             ></gv-input>
-            <span><sup>${this._getDaySuffix(this._state.yearly.day)}</sup> day</span>
+            <span><sup>${this._getDaySuffix(this._state.yearly.day)}</sup></span>
+            <span>day</span>
             <gv-date-picker small time strict name="yearly.time" .value="${this._state.yearly.time}"></gv-date-picker>
           </div>
 
@@ -610,7 +612,6 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
 
         sup {
           display: inline-block;
-          width: 16px;
           font-size: var(--gv-theme-font-size-s, 12px);
         }
 

--- a/src/molecules/gv-cron-editor.js
+++ b/src/molecules/gv-cron-editor.js
@@ -308,7 +308,7 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
           <div slot="title" class="generated-expression">
             <gv-input
               name="pro.value"
-              autofocus
+              .autofocus="${this.autofocus}"
               .value="${this.value}"
               id="cron-input"
               placeholder="* */30 * * * * (Every 30 min)"

--- a/src/molecules/gv-cron-editor.js
+++ b/src/molecules/gv-cron-editor.js
@@ -119,6 +119,7 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
       },
       pro: {
         value: '',
+        displayDetails: false,
       },
     };
 
@@ -293,6 +294,63 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
     return '';
   }
 
+  displayProDetails() {
+    this._state.pro.displayDetails = !this._state.pro.displayDetails;
+    this.requestUpdate();
+  }
+
+  renderProDetails() {
+    if (this._state.pro.displayDetails) {
+      return html` <div>
+        <div>Rules for:</div>
+        <div>
+          ${repeat(
+            this._docs,
+            (doc) => doc.id,
+            (doc) => {
+              const isCurrent = doc.id === this._currentDocumentationId;
+              return html`<gv-tag
+                @gv-tag:click="${this._onOpenDocumentation.bind(this, doc.id)}"
+                ?clickable="${!isCurrent}"
+                ?major="${isCurrent}"
+                ?minor="${!isCurrent}"
+                >${doc.label}</gv-tag
+              >`;
+            },
+          )}
+        </div>
+        <ul class="help">
+          <li>
+            <small>Allowed characters: <code>${this.allowedChar}</code></small>
+          </li>
+          <li>
+            <small>Allowed values: <code>${this.allowedValues}</code></small>
+          </li>
+        </ul>
+        <div>Examples:</div>
+        <ul class="help">
+          <li>
+            <small><code>*</code>: for each unit (0, 1, 2, 3...)</small>
+          </li>
+          <li>
+            <small><code>5,8</code>: units 5 and 8</small>
+          </li>
+          <li>
+            <small><code>2-5</code>: units from 2 to 5 (2, 3, 4, 5)</small>
+          </li>
+          <li>
+            <small><code>*/3</code>: every 3 units (0, 3, 6, 9...)</small>
+          </li>
+          <li>
+            <small><code>10-20/3</code>: every 3 units, between the tenth and the twentieth (10, 13, 16, 19)</small>
+          </li>
+        </ul>
+      </div>`;
+    }
+
+    return '';
+  }
+
   render() {
     return html`<div>
       ${this.renderLabel()}
@@ -405,47 +463,12 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
           </div>
 
           <div slot="content" id="pro" class="tab-content tab-content_pro">
-            <div>
-              ${repeat(
-                this._docs,
-                (doc) => doc.id,
-                (doc) => {
-                  const isCurrent = doc.id === this._currentDocumentationId;
-                  return html`<gv-tag
-                    @gv-tag:click="${this._onOpenDocumentation.bind(this, doc.id)}"
-                    ?clickable="${!isCurrent}"
-                    ?major="${isCurrent}"
-                    ?minor="${!isCurrent}"
-                    >${doc.label}</gv-tag
-                  >`;
-                },
-              )}
-            </div>
-            <ul>
-              <li>
-                <small>Allowed characters: <code>${this.allowedChar}</code></small>
-              </li>
-              <li>
-                <small>Allowed values: <code>${this.allowedValues}</code></small>
-              </li>
-            </ul>
-            <ul class="help">
-              <li>
-                <small><code>*</code>: for each unit (0, 1, 2, 3...)</small>
-              </li>
-              <li>
-                <small><code>5,8</code>: units 5 and 8</small>
-              </li>
-              <li>
-                <small><code>2-5</code>: units from 2 to 5 (2, 3, 4, 5)</small>
-              </li>
-              <li>
-                <small><code>*/3</code>: every 3 units (0, 3, 6, 9...)</small>
-              </li>
-              <li>
-                <small><code>10-20/3</code>: every 3 units, between the tenth and the twentieth (10, 13, 16, 19)</small>
-              </li>
-            </ul>
+            <gv-button link small class="tab-content_pro-details_btn" @click="${this.displayProDetails}">
+              ${this._state.pro.displayDetails
+                ? 'Hide information about cron rules and examples'
+                : 'Display information about cron rules and examples'}
+            </gv-button>
+            ${this.renderProDetails()}
           </div>
         </gv-tabs>
       </div>
@@ -568,6 +591,10 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
           align-items: normal;
           --gv-icon--s: 18px;
           padding: 0.2rem;
+        }
+
+        .tab-content_pro-details_btn {
+          --gv-button--fz: 12px;
         }
 
         .tab-content_pro > * {

--- a/src/molecules/gv-cron-editor.js
+++ b/src/molecules/gv-cron-editor.js
@@ -87,14 +87,14 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
     this.mode = 'pro';
     this._state = {
       seconds: {
-        seconds: 0,
+        seconds: 1,
       },
       minutes: {
-        minutes: 0,
+        minutes: 1,
         seconds: 0,
       },
       hourly: {
-        hours: 0,
+        hours: 1,
         minutes: 0,
         seconds: 0,
       },
@@ -317,20 +317,20 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
 
           <div slot="content" id="seconds" class="tab-content">
             <span>Every</span>
-            <gv-input small type="number" min="0" name="seconds.seconds" .value="${this._state.seconds.seconds}"></gv-input>
+            <gv-input small type="number" min="1" name="seconds.seconds" .value="${this._state.seconds.seconds}"></gv-input>
             <span>second(s)</span>
           </div>
 
           <div slot="content" id="minutes" class="tab-content">
             <span>Every</span>
-            <gv-input small type="number" min="0" name="minutes.minutes" .value="${this._state.minutes.minutes}"></gv-input>
+            <gv-input small type="number" min="1" name="minutes.minutes" .value="${this._state.minutes.minutes}"></gv-input>
             <span>minute(s) on second</span>
             <gv-input small type="number" min="0" max="59" name="minutes.seconds" .value="${this._state.minutes.seconds}"></gv-input>
           </div>
 
           <div slot="content" id="hourly" class="tab-content">
             <span>Every</span>
-            <gv-input small type="number" min="0" name="hourly.hours" .value="${this._state.hourly.hours}"></gv-input>
+            <gv-input small type="number" min="1" name="hourly.hours" .value="${this._state.hourly.hours}"></gv-input>
             <span>hour(s) on minute</span>
             <gv-input small type="number" min="0" max="59" name="hourly.minutes" .value="${this._state.hourly.minutes}"></gv-input>
             <span>and second</span>

--- a/src/molecules/gv-cron-editor.js
+++ b/src/molecules/gv-cron-editor.js
@@ -84,7 +84,6 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
       'November',
       'December',
     ];
-    this.mode = 'pro';
     this._state = {
       seconds: {
         seconds: 1,
@@ -137,6 +136,31 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
     this._small = false;
   }
 
+  tryToComputeAndInitModeFromValue() {
+    if (!this.value || this.mode) {
+      this.mode = this.mode || 'pro';
+      return;
+    }
+    const [seconds, minutes, hours, days, month, year] = this.value.split(' ');
+
+    if (days !== '*' || month !== '*' || year !== '*') {
+      // Theses cases are not simple to handle so just ignore them for now
+      this.mode = 'pro';
+    } else if (hours !== '*') {
+      this.mode = 'hourly';
+      this._state.hourly.hours = Number(hours.replace('*/', ''));
+      this._state.hourly.minutes = Number(minutes.replace('*/', ''));
+      this._state.hourly.seconds = Number(seconds.replace('*/', ''));
+    } else if (minutes !== '*') {
+      this.mode = 'minutes';
+      this._state.minutes.minutes = Number(minutes.replace('*/', ''));
+      this._state.minutes.seconds = Number(seconds.replace('*/', ''));
+    } else if (seconds !== '*') {
+      this.mode = 'seconds';
+      this._state.seconds.seconds = Number(seconds.replace('*/', ''));
+    }
+  }
+
   onResize({ width }) {
     this._truncateTabs = width < 750;
     this._small = width < 449;
@@ -159,6 +183,8 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
   }
 
   async firstUpdated() {
+    this.tryToComputeAndInitModeFromValue();
+
     // Give the browser a chance to paint
     // eslint-disable-next-line promise/param-names
     await new Promise((r) => setTimeout(r, 0));

--- a/src/molecules/gv-cron-editor.js
+++ b/src/molecules/gv-cron-editor.js
@@ -201,6 +201,10 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
     const {
       detail: { to },
     } = event;
+    if (to === 'pro') {
+      // Needs to be done first otherwise `value` is overridden before using it
+      this._state.pro.value = this.value;
+    }
     this.mode = to;
     this.generate();
     if (this.mode === 'pro') {

--- a/stories/molecules/gv-cron-editor.stories.js
+++ b/stories/molecules/gv-cron-editor.stories.js
@@ -22,6 +22,8 @@ export default {
   component: 'gv-cron-editor',
   parameters: {
     notes,
+    // DO NOT REACTIVATE a11y on these stories for now as the a11y checks are taking forever to run
+    a11y: { disable: true },
   },
 };
 

--- a/stories/molecules/gv-cron-editor.stories.js
+++ b/stories/molecules/gv-cron-editor.stories.js
@@ -40,3 +40,7 @@ export const Simple = makeStory(conf, {
 export const WithValue = makeStory(conf, {
   items: [{ value: '30 10 */5 * * MON-FRI' }],
 });
+
+export const WithAutomaticModeSelection = makeStory(conf, {
+  items: [{ value: '*/25 * * * * *' }],
+});


### PR DESCRIPTION
**Issue**

Closes https://github.com/gravitee-io/issues/issues/5039

**Description**

Multiple enhancements after the integration in the healthcheck page of APIM:
 - Use `autofocus` property instead of hardcoded one
 - Fix some alignments and split rules/examples of pro mode in 2 verticals blocks
 - Keep editor value when switching from any mode to `pro` mode
 - Add a simple algo to parse the input value, if defined, and select the correct mode accordingly. It works only for `seconds`, `minutes` and `hourly`
 - Set default value to 1 instead of 0 for `seconds`, `minutes` and `hourly` modes

**Screenshots**

![image](https://user-images.githubusercontent.com/4112568/107490954-d6e62d00-6b8a-11eb-80fd-19a38c6e9b71.png)

