### PR TITLE
fix(gv-cron-editor): compute mode from the value only for a few specific cases

### DIFF
--- a/src/molecules/gv-cron-editor.js
+++ b/src/molecules/gv-cron-editor.js
@@ -141,23 +141,25 @@ export class GvCronEditor extends withResizeObserver(InputElement(LitElement)) {
       this.mode = this.mode || 'pro';
       return;
     }
-    const [seconds, minutes, hours, days, month, year] = this.value.split(' ');
+    const [seconds, minutes, hours] = this.value.split(' ');
 
-    if (days !== '*' || month !== '*' || year !== '*') {
-      // Theses cases are not simple to handle so just ignore them for now
-      this.mode = 'pro';
-    } else if (hours !== '*') {
+    if (/\d+ \d+ \*\/\d+ \* \* \*/.test(this.value)) {
+      // Match: `1 42 */15 * * *`
       this.mode = 'hourly';
       this._state.hourly.hours = Number(hours.replace('*/', ''));
-      this._state.hourly.minutes = Number(minutes.replace('*/', ''));
-      this._state.hourly.seconds = Number(seconds.replace('*/', ''));
-    } else if (minutes !== '*') {
+      this._state.hourly.minutes = Number(minutes);
+      this._state.hourly.seconds = Number(seconds);
+    } else if (/\d+ \*\/\d+ \* \* \* \*/.test(this.value)) {
+      // Match: `1 */15 * * * *`
       this.mode = 'minutes';
       this._state.minutes.minutes = Number(minutes.replace('*/', ''));
-      this._state.minutes.seconds = Number(seconds.replace('*/', ''));
-    } else if (seconds !== '*') {
+      this._state.minutes.seconds = Number(seconds);
+    } else if (/\*\/\d+ \* \* \* \* \*/.test(this.value)) {
+      // Match: `*/15 * * * * *`
       this.mode = 'seconds';
       this._state.seconds.seconds = Number(seconds.replace('*/', ''));
+    } else {
+      this.mode = 'pro';
     }
   }
 

--- a/stories/molecules/gv-cron-editor.stories.js
+++ b/stories/molecules/gv-cron-editor.stories.js
@@ -42,5 +42,5 @@ export const WithValue = makeStory(conf, {
 });
 
 export const WithAutomaticModeSelection = makeStory(conf, {
-  items: [{ value: '*/25 * * * * *' }],
+  items: [{ value: '*/25 * * * * *' }, { value: '2 */25 * * * *' }, { value: '1 3 */25 * * *' }, { value: '* * */25 * * *' }],
 });


### PR DESCRIPTION
**Issue**

Related to https://github.com/gravitee-io/issues/issues/5039

**Description**

Compute mode from the input value only for a few specific cases

To avoid ending weird states we now set the state automatically only with input value matching something like:
 - `1 3 */25 * * *`
 - or `2 */25 * * * *`
 - or `*/25 * * * * *`

**Screenshot**
![image](https://user-images.githubusercontent.com/4112568/107745452-a03c1e00-6d14-11eb-9620-5f830911a527.png)
