### PR TITLE
fix(gv-link): crop text and add `...` when it is too long to fit

### DIFF
--- a/src/atoms/gv-link.js
+++ b/src/atoms/gv-link.js
@@ -74,7 +74,6 @@ export class GvLink extends LitElement {
       // language=css
       css`
         :host {
-          box-sizing: border-box;
           display: inline-flex;
           vertical-align: middle;
           --gv-icon--s: var(--gv-link-icon--s, 24px);
@@ -82,6 +81,12 @@ export class GvLink extends LitElement {
           --link--c: var(--gv-link--c, var(--gv-theme-font-color-dark, #262626));
           --pv: var(--gv-link-a--pv, 15px);
           --ph: var(--gv-link-a--ph, 15px);
+        }
+
+        *,
+        *:before,
+        *:after {
+          box-sizing: border-box;
         }
 
         a {
@@ -100,7 +105,6 @@ export class GvLink extends LitElement {
         }
 
         a > * {
-          flex: 1;
           align-self: center;
         }
 
@@ -125,6 +129,8 @@ export class GvLink extends LitElement {
           white-space: nowrap;
           margin: 0.3rem 0.5rem;
           text-decoration: var(--gv-link--td, none);
+          text-overflow: ellipsis;
+          overflow: hidden;
         }
 
         a.small span {

--- a/src/molecules/gv-nav.js
+++ b/src/molecules/gv-nav.js
@@ -51,6 +51,10 @@ export class GvNav extends LitElement {
           transition: all 150ms ease-in-out;
         }
 
+        gv-link {
+          --gv-link--ta: end;
+        }
+
         .vertical {
           display: flex;
           flex-direction: column;

--- a/stories/organisms/gv-user-menu.stories.js
+++ b/stories/organisms/gv-user-menu.stories.js
@@ -23,6 +23,7 @@ const routes = [
   { path: 'https://gravitee.io', title: 'External link', icon: 'communication:share', separator: true, target: '_blank' },
   { path: '#', title: 'My account', icon: 'general:user' },
   { path: '#', title: 'My apis', icon: 'cooking:cooking-book' },
+  { path: '#', title: 'My very long category that breaks the menu', icon: 'cooking:cooking-book' },
   { path: '#', title: 'My apps', icon: 'cooking:bowl' },
   { path: '#', title: Promise.resolve('logout'), icon: 'home:door-open', separator: true },
 ];

--- a/stories/organisms/gv-vertical-menu.stories.js
+++ b/stories/organisms/gv-vertical-menu.stories.js
@@ -38,6 +38,7 @@ const routes = [
   { path: '#', title: 'Categories', icon: 'layout:layout-arrange' },
   { path: '#', title: 'Featured', active: true, icon: 'home:flower#2' },
   { path: '#', title: 'Starred', icon: 'home:flower#1' },
+  { path: '#', title: 'My very long category that breaks the menu', icon: 'cooking:cooking-book' },
   { path: '#', title: 'Trendings', icon: 'appliances:fan' },
 ];
 const items = [{ routes }];


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/313

**Description**

I rework a bit the `gv-link` to fix an issue when using it in `gv-user-menu` with long text, see screenshots, so the text is now cropped and `...` is added when it is too long to fit. It doesn't look to break gv-link but it may be worth to check the other components you think they can be impacted.

**Screenshots**

Before:
![Capture d’écran 2021-02-12 à 14 11 54](https://user-images.githubusercontent.com/4112568/107777082-ad700180-6d42-11eb-94a5-9a3b85fe5e4a.png)

After:
![Capture d’écran 2021-02-12 à 14 12 14](https://user-images.githubusercontent.com/4112568/107777107-b6f96980-6d42-11eb-9e17-09bdddb27257.png)
![image](https://user-images.githubusercontent.com/4112568/107786167-cd58f280-6d4d-11eb-8bb0-d0ab19a25c79.png)

