### PR TITLE
fix(i18): use relative url to load default translation

### DIFF
--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -89,7 +89,7 @@ export function getAvailableLanguages() {
 
 export function loadDefaultTranslations() {
   setLanguage('en');
-  return fetch(`/i18n/${i18n._lang}.json`)
+  return fetch(`i18n/${i18n._lang}.json`)
     .then((response) => {
       return response.json();
     })


### PR DESCRIPTION
fix gravitee-io/issues5240