### PR TITLE
chore: remove hack on Storybook Preview block

### DIFF
--- a/stories/lib/make-story.js
+++ b/stories/lib/make-story.js
@@ -13,16 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as blockPreview from '@storybook/components/dist/esm/blocks/Preview';
 import { color, text } from '@storybook/addon-knobs';
 import { sequence } from './sequence';
 import customElements from '../../.docs/custom-elements.json';
-
-// Force html in preview examples
-const oldPreview = blockPreview.Preview;
-blockPreview.Preview = (pppp) => {
-  return oldPreview({ ...pppp, language: 'html', isExpanded: false });
-};
 
 export function makeStory(...configs) {
   const { name, docs, css, component, dom, items: rawItems = [{}], events = [], simulations = [], docsOnly = false } = Object.assign(


### PR DESCRIPTION
**Issue**

NA
**Description**

Previously there was a hack to do ?a thing?.
But, as of Storybook 6.2 it looks like this hack is making some story fails, for instance, the `gv-autocomplete` ones.
So I just removed it.

Notes: In the Storybook 6.2 upgrade PR (https://github.com/gravitee-io/gravitee-ui-components/pull/317) all the CI checks were green even if we "lost" the `gv-autocomplete` stories, including Chromatic. It seems to be a strange behaviour for Chromatic because new stories are reported as new and should be accepted manually whereas deleted stories don't trigger anything. 

I will contact @chromaui foxes to check is it's the intended behaviour or if we can do something on our side to prevent that. 

