### PR TITLE
Revert "fix(gv-select): let select go out of parent item"

### DIFF
--- a/src/atoms/gv-select.js
+++ b/src/atoms/gv-select.js
@@ -149,7 +149,7 @@ export class GvSelect extends withResizeObserver(InputElement(LitElement)) {
         .select__list {
           color: var(--c);
           list-style: none;
-          position: fixed;
+          position: absolute;
           background-color: var(--bgc-list);
           list-style: none;
           padding: 0;


### PR DESCRIPTION
**Issue**

This reverts commit 1494ce05 merged with PR https://github.com/gravitee-io/gravitee-ui-components/pull/302.

**Description**

The fix done in 1494ce05 is causing some issues on screens with a `gv-select` and a scrollbar, the options aren't scrolled with the rest of the page:

![image](https://user-images.githubusercontent.com/4112568/113982253-d09dc580-9848-11eb-8993-bfc3bf6f4557.png)
