### PR TITLE
feat(gv-chart-histogram): add new component

### DIFF
--- a/src/charts/gv-chart-histogram.js
+++ b/src/charts/gv-chart-histogram.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { LitElement } from 'lit-element';
+import { ChartElement } from '../mixins/chart-element';
+
+/**
+ * Histogram chart component
+ *
+ * @attr {Array} series - The series to display on the histogram chart.
+ * @attr {Object} options - The list of options to display.
+ *
+ */
+export class GvChartHistogram extends ChartElement(LitElement) {
+  async getOptions() {
+    let categories = [];
+    let yAxisTitle;
+    let title;
+    let subtitle;
+    let max;
+    let min = 0;
+
+    if (this.options) {
+      yAxisTitle = this.options.yAxisTitle;
+      title = this.options.title;
+      subtitle = this.options.subtitle;
+      categories = this.options.data.values || [];
+      min = this.options.min;
+      max = this.options.max;
+    }
+
+    if (this._series && this._series.values && this._series.values.length === 0) {
+      this._empty = true;
+    }
+
+    return {
+      chart: {
+        type: 'column',
+      },
+      title: {
+        text: title,
+        align: 'left',
+        style: { fontSize: '12px', fontWeight: '700' },
+      },
+      subtitle: {
+        text: subtitle,
+        align: 'left',
+        style: { fontSize: '11px', color: '#000000', opacity: '0.54' },
+      },
+      series: this._series.values,
+      xAxis: {
+        categories: categories,
+      },
+      legend: {
+        enabled: false,
+      },
+      yAxis: {
+        min,
+        max,
+        title: {
+          text: yAxisTitle,
+        },
+      },
+      plotOptions: {
+        column: {
+          pointPadding: 0.2,
+          borderWidth: 0,
+        },
+      },
+      tooltip: {
+        pointFormat: 'Value: <b>{point.y}</b>',
+      },
+    };
+  }
+}
+
+window.customElements.define('gv-chart-histogram', GvChartHistogram);

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export { GvTag } from './atoms/gv-tag';
 export { GvText } from './atoms/gv-text';
 export { GvChartBar } from './charts/gv-chart-bar';
 export { GvChartGauge } from './charts/gv-chart-gauge';
+export { GvChartHistogram } from './charts/gv-chart-histogram';
 export { GvChartLine } from './charts/gv-chart-line';
 export { GvChartMap } from './charts/gv-chart-map';
 export { GvChartPie } from './charts/gv-chart-pie';

--- a/stories/charts/gv-chart-histogram.stories.js
+++ b/stories/charts/gv-chart-histogram.stories.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import notes from '../../.docs/gv-chart-histogram.md';
+import '../../src/charts/gv-chart-histogram';
+import { makeStory, storyWait } from '../lib/make-story';
+
+const series = {
+  values: [
+    {
+      name: '9ec7b0e2-a649-40a3-87b0-e2a649e0a377',
+      color: '#5cb85c',
+      data: [100.0, 80.0, 90.0, 100.0, 0, 0, 0, 20.0, 30.0, 50.0, 60.0, 70.0, 0],
+    },
+  ],
+};
+
+const options = {
+  yAxisTitle: 'Availability (%)',
+  title: 'Global availability',
+  subtitle: 'Global availability including results of all health-checked endpoints (see below).',
+  min: 0,
+  max: 100,
+  data: {
+    name: 'timestamp',
+    values: [
+      '20. Apr',
+      '21. Apr',
+      '22. Apr',
+      '23. Apr',
+      '24. Apr',
+      '26. Apr',
+      '27. Apr',
+      '28. Apr',
+      '29. Apr',
+      '30. Apr',
+      '1. May',
+      '2. May',
+      '3. May',
+    ],
+  },
+};
+
+export default {
+  title: 'charts/gv-chart-histogram',
+  component: 'gv-chart-histogram',
+  parameters: {
+    notes,
+    chromatic: { disable: true },
+  },
+};
+
+const conf = {
+  component: 'gv-chart-histogram',
+  css: `
+    gv-chart-histogram {
+      min-height: 200px;
+    }
+  `,
+};
+
+export const Basics = makeStory(conf, {
+  items: [{ series, options }],
+});
+
+export const Empty = makeStory(conf, {
+  items: [{ series: [], options }],
+});
+
+let seriesResolver;
+export const Loading = makeStory(conf, {
+  items: [{}],
+  simulations: [
+    storyWait(0, ([component]) => {
+      component.series = new Promise((resolve) => (seriesResolver = resolve));
+      component.options = options;
+    }),
+
+    storyWait(750, () => {
+      seriesResolver(series);
+    }),
+  ],
+});

--- a/wc/gv-chart-histogram.js
+++ b/wc/gv-chart-histogram.js
@@ -1,0 +1,1 @@
+import '../src/charts/gv-chart-histogram';


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/489

**Description**

- [x] Add new histogram chart. 

This chart is needed to display the nodes availability like on APIM. For the moment I kept this component as simple as I can. Everything is not configurable. Feel free to tell me if you would like to make something configurable.

**Additional context**
 Here what we have on apim
![Screenshot from 2021-05-04 12-51-53](https://user-images.githubusercontent.com/25704259/117007352-d670b480-ace9-11eb-9250-5767291f9389.png)

Here is the new component
![image](https://user-images.githubusercontent.com/25704259/117007589-218ac780-acea-11eb-9513-7d7dfc94bbcb.png)



