### PR TITLE
feat(gv-chart-histogram): improve histogram chart options usage

### DIFF
--- a/src/charts/gv-chart-histogram.js
+++ b/src/charts/gv-chart-histogram.js
@@ -25,20 +25,16 @@ import { ChartElement } from '../mixins/chart-element';
  */
 export class GvChartHistogram extends ChartElement(LitElement) {
   async getOptions() {
-    let categories = [];
-    let yAxisTitle;
+    let yAxis;
     let title;
     let subtitle;
-    let max;
-    let min = 0;
+    let plotOptions;
 
     if (this.options) {
-      yAxisTitle = this.options.yAxisTitle;
+      yAxis = this.options.yAxis;
       title = this.options.title;
       subtitle = this.options.subtitle;
-      categories = this.options.data.values || [];
-      min = this.options.min;
-      max = this.options.max;
+      plotOptions = this.options.plotOptions;
     }
 
     if (this._series && this._series.values && this._series.values.length === 0) {
@@ -48,6 +44,7 @@ export class GvChartHistogram extends ChartElement(LitElement) {
     return {
       chart: {
         type: 'column',
+        backgroundColor: 'transparent',
       },
       title: {
         text: title,
@@ -61,24 +58,17 @@ export class GvChartHistogram extends ChartElement(LitElement) {
       },
       series: this._series.values,
       xAxis: {
-        categories: categories,
+        type: 'datetime',
+        dateTimeLabelFormats: {
+          month: '%e. %b',
+          year: '%b',
+        },
       },
       legend: {
         enabled: false,
       },
-      yAxis: {
-        min,
-        max,
-        title: {
-          text: yAxisTitle,
-        },
-      },
-      plotOptions: {
-        column: {
-          pointPadding: 0.2,
-          borderWidth: 0,
-        },
-      },
+      yAxis,
+      plotOptions,
       tooltip: {
         pointFormat: 'Value: <b>{point.y}</b>',
       },

--- a/stories/charts/gv-chart-histogram.stories.js
+++ b/stories/charts/gv-chart-histogram.stories.js
@@ -22,34 +22,29 @@ const series = {
     {
       name: '9ec7b0e2-a649-40a3-87b0-e2a649e0a377',
       color: '#5cb85c',
-      data: [100.0, 80.0, 90.0, 100.0, 0, 0, 0, 20.0, 30.0, 50.0, 60.0, 70.0, 0],
+      data: [100.0, 80.0, 90.0, 100.0, 0, 0, 0, 20.0, 30.0, 50.0, 60.0, 70.0, 0, 90.0, 100.0, 0, 0, 0, 20.0, 30.0, 50.0, 60.0, 70.0, 0],
     },
   ],
 };
 
 const options = {
-  yAxisTitle: 'Availability (%)',
   title: 'Global availability',
   subtitle: 'Global availability including results of all health-checked endpoints (see below).',
-  min: 0,
-  max: 100,
-  data: {
-    name: 'timestamp',
-    values: [
-      '20. Apr',
-      '21. Apr',
-      '22. Apr',
-      '23. Apr',
-      '24. Apr',
-      '26. Apr',
-      '27. Apr',
-      '28. Apr',
-      '29. Apr',
-      '30. Apr',
-      '1. May',
-      '2. May',
-      '3. May',
-    ],
+  yAxis: {
+    min: 0,
+    max: 100,
+    title: {
+      text: 'Availability',
+    },
+    labels: {
+      format: '{value}%',
+    },
+  },
+  plotOptions: {
+    series: {
+      pointInterval: 12500,
+      pointStart: 1620283750000,
+    },
   },
 };
 
@@ -88,7 +83,7 @@ export const Loading = makeStory(conf, {
       component.options = options;
     }),
 
-    storyWait(750, () => {
+    storyWait(1500, () => {
       seriesResolver(series);
     }),
   ],


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/489

**Description**

- [x] use the entier options object to be more flexible on the display
- [x] use plotOptions object
- [x] change background 
- [x] adapt xAxis values format according to series values 

**Additional context**
 Here what we had before
![image](https://user-images.githubusercontent.com/25704259/117007589-218ac780-acea-11eb-9513-7d7dfc94bbcb.png)

Here is what we have now:
![image](https://user-images.githubusercontent.com/25704259/117293934-53c73100-ae72-11eb-9076-24bebd6b46a1.png)


