### PR TITLE
Move some dependencies to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15217,9 +15217,10 @@
       "dev": true
     },
     "highcharts": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.0.0.tgz",
-      "integrity": "sha512-MJCtidFytGSQvsV3OEM+vFTLpjUcp7jmFpLn8h3oL4WKp0gxUOQg6Nw00sqMWGdiadst0gOZO4804zynTcYjZQ=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.1.0.tgz",
+      "integrity": "sha512-K7HUuKhEylZ1pMdzGR35kPgUmpp0MDNpaWhEMkGiC5Jfzg/endtTLHJN2lsFqEO+xoN7AykBK98XaJPEpsrLyA==",
+      "dev": true
     },
     "highlight.js": {
       "version": "10.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,11 +32,12 @@
       }
     },
     "@asciidoctor/core": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.0.tgz",
-      "integrity": "sha512-WN/mFuU4SeWaDqpGvRwAf+Tq2T8NQkVVpZ3Ne1/ZRxDKElzFkqq8bGbmxSMWmMVzC+H9ZO1YxxbOjhWEiNvpOA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.4.tgz",
+      "integrity": "sha512-rk7YSD6QAY6kInW5JVYi2ICjC3r90kXGlARwpfKQ99e/qy/2Vq31coL6nFFiWRuQxbh4EBqzUbC5uUUUjiu+Vw==",
+      "dev": true,
       "requires": {
-        "asciidoctor-opal-runtime": "0.3.0",
+        "asciidoctor-opal-runtime": "0.3.3",
         "unxhr": "1.0.1"
       }
     },
@@ -8663,18 +8664,20 @@
       }
     },
     "asciidoctor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-2.2.0.tgz",
-      "integrity": "sha512-w5oBMYPaA5RP/Qlv6XQzWE7kSf8d9sLMRBItcU+nn7E/FF9yGLUd1p/dzqWiu600KyNHBpp8Ml/VTaGjUm6LrQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-2.2.4.tgz",
+      "integrity": "sha512-/Z7hDwbNwaoGZMcm7HgAza6Z19gIPjiqvh1aQjiObab/Mncf6M1xs08Gy4dGqezfzvFvMH6Ur4s1ohfU/l1x5A==",
+      "dev": true,
       "requires": {
         "@asciidoctor/cli": "3.4.0",
-        "@asciidoctor/core": "2.2.0"
+        "@asciidoctor/core": "2.2.4"
       },
       "dependencies": {
         "@asciidoctor/cli": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/@asciidoctor/cli/-/cli-3.4.0.tgz",
           "integrity": "sha512-jOtxA0I6zB+6z+GGwm9+xhlmGTqCTkFPE902L6fauFlE6v7LxjhLYNxvjDVyn0zMrFLybvoSRcAnM3DcticNoQ==",
+          "dev": true,
           "requires": {
             "yargs": "15.3.1"
           }
@@ -8682,12 +8685,14 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         },
         "cliui": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
           "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
@@ -8697,12 +8702,14 @@
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -8711,12 +8718,14 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -8725,6 +8734,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -8732,12 +8742,14 @@
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
         },
         "string-width": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
-          "integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -8748,6 +8760,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -8756,6 +8769,7 @@
           "version": "15.3.1",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
           "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "dev": true,
           "requires": {
             "cliui": "^6.0.0",
             "decamelize": "^1.2.0",
@@ -8776,14 +8790,16 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/asciidoctor-highlight.js/-/asciidoctor-highlight.js-0.3.0.tgz",
       "integrity": "sha512-L8dPfUoOVAfut4WlsLMe40EdJphaIhMo3d0l2P5rOCB8l1dd+VQfbMNFZWVjkgwri/dXFZ/CW0R5+JSzPdo7iQ==",
+      "dev": true,
       "requires": {
         "highlight.js": "^10.4.1"
       }
     },
     "asciidoctor-opal-runtime": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.0.tgz",
-      "integrity": "sha512-YapVwl2qbbs6sIe1dvAlMpBzQksFVTSa2HOduOKFNhZlE9bNmn+moDgGVvjWPbzMPo/g8gItyTHfWB2u7bQxag==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.3.tgz",
+      "integrity": "sha512-/CEVNiOia8E5BMO9FLooo+Kv18K4+4JBFRJp8vUy/N5dMRAg+fRNV4HA+o6aoSC79jVU/aT5XvUpxSxSsTS8FQ==",
+      "dev": true,
       "requires": {
         "glob": "7.1.3",
         "unxhr": "1.0.1"
@@ -8793,6 +8809,7 @@
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -9253,7 +9270,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -9606,6 +9624,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10195,7 +10214,8 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
     },
     "camelcase-css": {
       "version": "2.0.1",
@@ -11283,7 +11303,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -12076,7 +12097,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -14430,7 +14452,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.13",
@@ -14536,7 +14559,8 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -15223,9 +15247,10 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
-      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ=="
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.2.tgz",
+      "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -16009,6 +16034,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -16017,7 +16043,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.7",
@@ -21153,6 +21180,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -22926,6 +22954,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -23186,6 +23215,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -23236,7 +23266,8 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "package-json": {
       "version": "6.5.0",
@@ -23518,7 +23549,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -25421,12 +25453,14 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
     },
     "requireindex": {
       "version": "1.2.0",
@@ -26273,7 +26307,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.1",
@@ -28446,7 +28481,8 @@
     "unxhr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.0.1.tgz",
-      "integrity": "sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg=="
+      "integrity": "sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg==",
+      "dev": true
     },
     "unzip-response": {
       "version": "2.0.1",
@@ -29906,7 +29942,8 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
     },
     "which-pm-runs": {
       "version": "1.0.0",
@@ -30011,6 +30048,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -30020,12 +30058,14 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -30034,6 +30074,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -30041,22 +30082,26 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
           "integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -30067,6 +30112,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }
@@ -30076,7 +30122,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",
@@ -30137,7 +30184,8 @@
     "y18n": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",
@@ -30175,6 +30223,7 @@
       "version": "18.1.3",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
       "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2217,7 +2217,8 @@
     "@highcharts/map-collection": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@highcharts/map-collection/-/map-collection-1.1.3.tgz",
-      "integrity": "sha512-Kb31dEQc7Kf7dxkmJEUjYlZ2wtRftEumJR/bq3SwvcviZeEhz+t6vMLXqS9qxfeO0UzSOaTCLiNMBsg/W6d7/g=="
+      "integrity": "sha512-Kb31dEQc7Kf7dxkmJEUjYlZ2wtRftEumJR/bq3SwvcviZeEhz+t6vMLXqS9qxfeO0UzSOaTCLiNMBsg/W6d7/g==",
+      "dev": true
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@formatjs/intl-relativetimeformat": "^4.5.9",
-    "@highcharts/map-collection": "^1.1.3",
     "asciidoctor": "^2.2.0",
     "asciidoctor-highlight.js": "^0.3.0",
     "clipboard-copy": "^3.1.0",
@@ -75,6 +74,7 @@
     "@babel/preset-env": "^7.11.5",
     "@commitlint/cli": "^12.0.0",
     "@commitlint/config-conventional": "^12.0.0",
+    "@highcharts/map-collection": "^1.1.3",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
     "@storybook/addon-a11y": "6.3.0-alpha.43",
@@ -124,5 +124,13 @@
     "web-component-analyzer": "1.1.6",
     "webpack-env": "^0.8.0",
     "webpack-merge": "^5.4.1"
+  },
+  "peerDependencies": {
+    "@highcharts/map-collection": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@highcharts/map-collection": {
+      "optional": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "jdenticon": "^2.2.0",
     "jsonschema": "^1.4.0",
     "lit-element": "^2.5.1",
-    "lit-html": "^1.4.1",
     "messageformat": "^2.3.0",
     "object-path": "^0.11.5",
     "resize-observer-polyfill": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "clipboard-copy": "^3.1.0",
     "codemirror": "^5.59.2",
     "date-fns": "^2.16.1",
-    "highcharts": "^9.0.0",
     "highlight.js": "^10.4.0",
     "jdenticon": "^2.2.0",
     "jsonschema": "^1.4.0",
@@ -103,6 +102,7 @@
     "github-markdown-css": "^3.0.1",
     "glob": "^7.1.4",
     "gzip-size": "^5.1.1",
+    "highcharts": "^9.1.0",
     "html-loader": "^0.5.5",
     "html-to-react": "^1.4.2",
     "husky": "^4.3.8",
@@ -126,10 +126,14 @@
     "webpack-merge": "^5.4.1"
   },
   "peerDependencies": {
-    "@highcharts/map-collection": "^1.0.0"
+    "@highcharts/map-collection": "^1.0.0",
+    "highcharts": "^8.0.0 || ^9.0.0"
   },
   "peerDependenciesMeta": {
     "@highcharts/map-collection": {
+      "optional": true
+    },
+    "highcharts": {
       "optional": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "src",
     "wc"
   ],
+  "repository": {
+    "url": "https://github.com/gravitee-io/gravitee-ui-components",
+    "type": "git"
+  },
   "scripts": {
     "build": "npm run docs && npm run check:i18n && npm run generate:theme && npm run generate:dist && build-storybook -s assets --quiet",
     "check:i18n": "node tasks/check-i18n.js",

--- a/package.json
+++ b/package.json
@@ -56,12 +56,9 @@
   },
   "dependencies": {
     "@formatjs/intl-relativetimeformat": "^4.5.9",
-    "asciidoctor": "^2.2.0",
-    "asciidoctor-highlight.js": "^0.3.0",
     "clipboard-copy": "^3.1.0",
     "codemirror": "^5.59.2",
     "date-fns": "^2.16.1",
-    "highlight.js": "^10.4.0",
     "jdenticon": "^2.2.0",
     "jsonschema": "^1.4.0",
     "lit-element": "^2.5.1",
@@ -86,6 +83,8 @@
     "@storybook/theming": "6.3.0-alpha.43",
     "@storybook/web-components": "6.3.0-alpha.43",
     "asciidoc-loader": "^0.2.0",
+    "asciidoctor": "^2.2.4",
+    "asciidoctor-highlight.js": "^0.3.0",
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-template-html-minifier": "^4.0.0",
@@ -106,6 +105,7 @@
     "glob": "^7.1.4",
     "gzip-size": "^5.1.1",
     "highcharts": "^9.1.0",
+    "highlight.js": "^10.7.2",
     "html-loader": "^0.5.5",
     "html-to-react": "^1.4.2",
     "husky": "^4.3.8",
@@ -129,14 +129,26 @@
     "webpack-merge": "^5.4.1"
   },
   "peerDependencies": {
+    "asciidoctor": "^2.0.0",
+    "asciidoctor-highlight.js": "^0.3.0",
     "@highcharts/map-collection": "^1.0.0",
-    "highcharts": "^8.0.0 || ^9.0.0"
+    "highcharts": "^8.0.0 || ^9.0.0",
+    "highlight.js": "^10.7.0"
   },
   "peerDependenciesMeta": {
+    "asciidoctor": {
+      "optional": true
+    },
+    "asciidoctor-highlight.js": {
+      "optional": true
+    },
     "@highcharts/map-collection": {
       "optional": true
     },
     "highcharts": {
+      "optional": true
+    },
+    "highlight.js": {
       "optional": true
     }
   }

--- a/src/charts/gv-chart-bar.js
+++ b/src/charts/gv-chart-bar.js
@@ -22,6 +22,10 @@ import { dispatchCustomEvent } from '../lib/events';
 /**
  * Bar chart component
  *
+ * ⚠️ This component is based on `highcharts`.
+ * To use this component in your project be sure the dependency is installed or
+ * install it with: `npm install highcharts --save`
+ *
  * @fires gv-chart-bar:select - Custom event with selected value
  *
  * @attr {Array} series - The series to display on the bar chart.

--- a/src/charts/gv-chart-gauge.js
+++ b/src/charts/gv-chart-gauge.js
@@ -22,6 +22,10 @@ import HCSolidGauge from 'highcharts/modules/solid-gauge';
 /**
  * Gauge chart component
  *
+ * ⚠️ This component is based on `highcharts`.
+ * To use this component in your project be sure the dependency is installed or
+ * install it with: `npm install highcharts --save`
+ *
  * @attr {number} max - The maximum value of the gauge.
  * @attr {Array} series - Array of the series to display.
  *

--- a/src/charts/gv-chart-histogram.js
+++ b/src/charts/gv-chart-histogram.js
@@ -19,6 +19,10 @@ import { ChartElement } from '../mixins/chart-element';
 /**
  * Histogram chart component
  *
+ * ⚠️ This component is based on `highcharts`.
+ * To use this component in your project be sure the dependency is installed or
+ * install it with: `npm install highcharts --save`
+ *
  * @attr {Array} series - The series to display on the histogram chart.
  * @attr {Object} options - The list of options to display.
  *

--- a/src/charts/gv-chart-line.js
+++ b/src/charts/gv-chart-line.js
@@ -24,6 +24,10 @@ import { getLanguage } from '../lib/i18n';
 /**
  * Line chart component
  *
+ * ⚠️ This component is based on `highcharts`.
+ * To use this component in your project be sure the dependency is installed or
+ * install it with: `npm install highcharts --save`
+ *
  * @fires gv-chart-line:zoom - Custom event with zoomed timeframe
  * @fires gv-chart-line:select - Custom event with selected value
  *

--- a/src/charts/gv-chart-map.js
+++ b/src/charts/gv-chart-map.js
@@ -21,7 +21,11 @@ import Highcharts from 'highcharts';
 import { dispatchCustomEvent } from '../lib/events';
 
 /**
- * Map chart component
+ * Map chart component.
+ *
+ * ⚠️ This component is based on `@highcharts/map-collection`.
+ * To use this component in your project be sure the dependency is installed or
+ * install it with: `npm install @highcharts/map-collection --save`
  *
  * @fires gv-chart-map:select - Custom event with selected value
  *

--- a/src/charts/gv-chart-map.js
+++ b/src/charts/gv-chart-map.js
@@ -23,9 +23,9 @@ import { dispatchCustomEvent } from '../lib/events';
 /**
  * Map chart component.
  *
- * ⚠️ This component is based on `@highcharts/map-collection`.
- * To use this component in your project be sure the dependency is installed or
- * install it with: `npm install @highcharts/map-collection --save`
+ * ⚠️ This component is based on `highcharts` and `@highcharts/map-collection`.
+ * To use this component in your project be sure the dependencies are installed or
+ * install them with: `npm install highcharts @highcharts/map-collection --save`
  *
  * @fires gv-chart-map:select - Custom event with selected value
  *

--- a/src/charts/gv-chart-pie.js
+++ b/src/charts/gv-chart-pie.js
@@ -22,6 +22,10 @@ import { dispatchCustomEvent } from '../lib/events';
 /**
  * Pie chart component
  *
+ * ⚠️ This component is based on `highcharts`.
+ * To use this component in your project be sure the dependency is installed or
+ * install it with: `npm install highcharts --save`
+ *
  * @fires gv-chart-pie:select - Custom event with selected value
  *
  * @attr {Array} series - The series to display on the pie chart.

--- a/src/policy-studio/gv-policy-studio.js
+++ b/src/policy-studio/gv-policy-studio.js
@@ -38,6 +38,10 @@ const FLOW_STEP_FORM_ID = 'flow-step-form';
 /**
  *  Studio Policy component
  *
+ * ⚠️ This component is based on `asciidoctor`, `highlight.js` and `asciidoctor-highlight.js`.
+ * To use this component in your project be sure the dependencies are installed or
+ * install them with: `npm install asciidoctor highlight.js asciidoctor-highlight.js --save`
+ *
  * @fires gv-policy-studio:select-policy - Select policy event
  * @fires gv-policy-studio:save - When request savet
  *


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-ui-components/issues/299

**Description**

I moved `asciidoctor`, `asciidoctor-highlight.js`, `highlight`, `highchart` and `@highcharts/map-collection` to peer dependencies.

This has been done in order to:
- ensure we are using the version from user's project and avoid having duplicated versions
- reduce the size of this package by making these dependencies optional peer dependencies. And so allow skipping these dependencies for projects not using any related components (chart, map or AsciiDoc related).

**_BREAKING CHANGE - MIGRATION GUIDE_**:

The dependency `asciidoctor`, `asciidoctor-highlight.js`, `highlight`, `highchart` and `@highcharts/map-collection` are no longer shipped with `@gravitee/ui-components. 

1. Project using asciidoc related components must install the dependencies directly.
    To do so, after updating `@gravitee/ui-components`, just run:
    ```bash
    npm i asciidoctor asciidoctor-highlight.js highlight
    ```

2. Project using chart related components must install the dependencies directly.
    To do so, after updating `@gravitee/ui-components`, just run:
    ```bash
    npm i highcharts
    ```

3. Project using map-related components must install the dependencies directly.
    To do so, after updating `@gravitee/ui-components`, just run:
    ```bash
    npm i @highcharts/map-collection
    ```

--

I also remove redundant dependency on `lit-html` and add missing `repository` attribute in `package.json`