### PR TITLE
feat: add DSL to disable a field that matches some condition

### DIFF
--- a/src/organisms/gv-schema-form-control.js
+++ b/src/organisms/gv-schema-form-control.js
@@ -274,8 +274,8 @@ export class GvSchemaFormControl extends LitElement {
     }
   }
 
-  async _getUpdateComplete() {
-    await super._getUpdateComplete();
+  async getUpdateComplete() {
+    await super.getUpdateComplete();
     await Promise.all(this.getControls().map((e) => e.updateComplete));
   }
 

--- a/src/organisms/gv-schema-form.js
+++ b/src/organisms/gv-schema-form.js
@@ -235,13 +235,7 @@ export class GvSchemaForm extends LitElement {
     // This is require to clean cache of <gv-schema-form-control>
     const control = { ...this.schema.properties[key] };
     const isRequired = this.schema.required && this.schema.required.includes(key);
-
-    let isDisabled = this.schema.disabled && this.schema.disabled.includes(key);
-    const condition = control['x-schema-form'] && control['x-schema-form'].disabled;
-    if (!isDisabled && condition) {
-      // test 'x-scheam-form.disabled' only if the field isn't explicitly defined into the 'disabled' array
-      isDisabled = this._evaluateDisabledCondition(condition);
-    }
+    const isDisabled = (this.schema.disabled && this.schema.disabled.includes(key)) || this._evaluateCondition(control, 'disabled');
 
     const value = get(this._values, key);
     return html`<gv-schema-form-control
@@ -256,10 +250,14 @@ export class GvSchemaForm extends LitElement {
     ></gv-schema-form-control>`;
   }
 
-  _evaluateDisabledCondition(condition) {
+  _evaluateCondition(control, conditionKey) {
+    if (control['x-schema-form'] == null || control['x-schema-form'][conditionKey] == null) {
+      return false;
+    }
+    const condition = control['x-schema-form'][conditionKey];
     if (!Array.isArray(condition)) {
       // condition isn't an array, ignore the condition
-      console.warn("'disable' attribute of 'x-schema-form' should be an array");
+      console.warn(`'${conditionKey}' attribute of 'x-schema-form' should be an array`);
       return false;
     }
 
@@ -281,7 +279,7 @@ export class GvSchemaForm extends LitElement {
           result = result && this._evaluateDefCondition(operation);
           break;
         default:
-          console.warn("Unsupported operator '" + operator + "' on disable condition");
+          console.warn(`Unsupported operator '${operator}' on disable condition`);
           result = false;
           break;
       }

--- a/stories/organisms/gv-schema-form.stories.js
+++ b/stories/organisms/gv-schema-form.stories.js
@@ -117,6 +117,9 @@ export const Mixed = makeStory(conf, {
       '@gv-expression-language:ready': ({ detail }) => {
         detail.currentTarget.grammar = grammar;
       },
+      '@gv-schema-form:change': ({ detail }) => {
+        detail.target.values = detail.values;
+      },
       'validate-on-render': true,
     },
   ],

--- a/stories/organisms/gv-schema-form.test.js
+++ b/stories/organisms/gv-schema-form.test.js
@@ -34,6 +34,22 @@ describe('S C H E M A  F O R M', () => {
     page.clear();
   });
 
+  const mixedControls = [
+    'body',
+    'el',
+    'body-with-el',
+    'path-operator',
+    'resources',
+    'another-list-resources',
+    'attributes',
+    'timeToLiveSeconds',
+    'useResponseCacheHeaders',
+    'select',
+    'multiselect',
+    'cron',
+    'disabled',
+  ];
+
   const checkControl = (id, attributes = []) => {
     const ids = id.split('.');
     const acc = [];
@@ -62,20 +78,7 @@ describe('S C H E M A  F O R M', () => {
     expect(component).toEqual(querySelector('gv-schema-form'));
 
     component.updateComplete.then(() => {
-      expect(component.getControls().map((e) => e.id)).toEqual([
-        'body',
-        'el',
-        'body-with-el',
-        'path-operator',
-        'resources',
-        'another-list-resources',
-        'attributes',
-        'timeToLiveSeconds',
-        'useResponseCacheHeaders',
-        'select',
-        'multiselect',
-        'cron',
-      ]);
+      expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
 
       checkControl('body');
       checkControl('el');
@@ -106,25 +109,13 @@ describe('S C H E M A  F O R M', () => {
       multiselect: ['a', 'b', 'c'],
       attributes: [{ name: 'foo', value: 'bar' }],
       cron: '*/30 * * * * SUN-MON',
+      disabled: 'Simple Test',
     };
     component.requestUpdate();
 
     component.updateComplete.then(() => {
       setTimeout(() => {
-        expect(component.getControls().map((e) => e.id)).toEqual([
-          'body',
-          'el',
-          'body-with-el',
-          'path-operator',
-          'resources',
-          'another-list-resources',
-          'attributes',
-          'timeToLiveSeconds',
-          'useResponseCacheHeaders',
-          'select',
-          'multiselect',
-          'cron',
-        ]);
+        expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
 
         checkControl('body', { value: '<xml>foobar</xml>' });
         checkControl('path-operator', { value: { operator: 'EQUALS', path: '/foobar' } });
@@ -138,6 +129,46 @@ describe('S C H E M A  F O R M', () => {
         checkControl('attributes', { value: [{ name: 'foo', value: 'bar' }] });
         checkControl('attributes.0', { value: { name: 'foo', value: 'bar' } });
         checkControl('cron', { value: '*/30 * * * * SUN-MON' });
+        checkControl('disabled', { value: 'Simple Test' });
+        done();
+      }, 0);
+    });
+  });
+
+  test('should disable element if "select" is "a"', (done) => {
+    component.values = {
+      select: 'a',
+      disabled: 'Simple Test',
+    };
+    component.requestUpdate();
+
+    component.updateComplete.then(() => {
+      setTimeout(() => {
+        expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+
+        checkControl('disabled', { value: 'Simple Test' });
+
+        expect(component.getControl('disabled').disabled).toBeTruthy();
+        done();
+      }, 0);
+    });
+  });
+
+  test('should not disable element if "select" is not "a"', (done) => {
+    component.values = {
+      select: 'b',
+      disabled: 'Simple Test',
+    };
+    component.requestUpdate();
+
+    component.updateComplete.then(() => {
+      setTimeout(() => {
+        expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+
+        checkControl('disabled', { value: 'Simple Test' });
+
+        expect(component.getControl('disabled').disabled).toBeFalsy();
+
         done();
       }, 0);
     });

--- a/stories/resources/schemas/mixed.json
+++ b/stories/resources/schemas/mixed.json
@@ -145,7 +145,7 @@
       }
     },
     "disabled": {
-      "title": "Disbaled field if 'Simple select' is 'a'",
+      "title": "Disabled field if 'Simple select' is 'a'",
       "type": "string",
       "x-schema-form": {
         "disabled": [{ "$def": "select" }, { "$eq": { "select": "a" } }]

--- a/stories/resources/schemas/mixed.json
+++ b/stories/resources/schemas/mixed.json
@@ -143,6 +143,13 @@
       "x-schema-form": {
         "cron-expression": true
       }
+    },
+    "disabled": {
+      "title": "Disbaled field if 'Simple select' is 'a'",
+      "type": "string",
+      "x-schema-form": {
+        "disabled": [{ "$def": "select" }, { "$eq": { "select": "a" } }]
+      }
     }
   },
   "required": ["multiselect", "timeToLiveSeconds"]


### PR DESCRIPTION
fixes gravitee-io/gravitee-ui-components#350

**Issue**

https://github.com/gravitee-io/gravitee-ui-components/issues/350

**Description**

Addition of a DSL into the x-schema-form entry of the gv-schema-form component.
This DSL allows to disable a field that matches conditions.


