### PR TITLE
Update Renovate config to group all non-major devDep update in a single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": ["config:base"],
   "prConcurrentLimit": 3,
-  "dependencyDashboard": true
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "devDependencies (non-major)"
+    }
+  ]
 }


### PR DESCRIPTION
**Issue**

NA

**Description**

Update Renovate config to group all non-major devDep update in a single PR.
For details see: https://docs.renovatebot.com/configuration-options/#packagerules

