### PR TITLE
feat: create flow structure based on the flow schema

### DIFF
--- a/stories/policy-studio/gv-policy-studio.stories.js
+++ b/stories/policy-studio/gv-policy-studio.stories.js
@@ -277,3 +277,18 @@ export const AM = makeStory(conf, {
     },
   ],
 });
+
+export const AMEditable = makeStory(conf, {
+  items: [
+    {
+      policies: amPolicies.data.map((policy) => {
+        policy.icon = icon;
+        return policy;
+      }),
+      definition: amDefinition,
+      flowSchema: amForm,
+      '@gv-policy-studio:fetch-documentation': fetchPolicyDocumentation.bind(this),
+      'can-add': true,
+    },
+  ],
+});

--- a/stories/resources/schemas/am.json
+++ b/stories/resources/schemas/am.json
@@ -1,16 +1,18 @@
 {
   "type": "object",
-  "id": "apim",
+  "id": "am",
   "properties": {
     "name": {
       "title": "Name",
       "description": "The name of flow. If empty, the name will be generated with the path and methods",
-      "type": "string"
+      "type": "string",
+      "default": "New Flow"
     },
     "type": {
       "title": "Type",
       "description": "The type of flow",
       "type": "string",
+      "default": "ROOT",
       "enum": ["ROOT", "LOGIN", "CONSENT", "REGISTER"]
     },
     "condition": {
@@ -20,5 +22,5 @@
     }
   },
   "required": [],
-  "disabled": ["type", "condition"]
+  "disabled": []
 }


### PR DESCRIPTION
fixes gravitee-io/gravitee-ui-components#349

**Issue**

https://github.com/gravitee-io/gravitee-ui-components/issues/349

**Description**

Create flow instance based on the flow schema to avoid ugly conditions to adapt the flow content for APIM or AM 

