### PR TITLE
Remove source minification when building the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "semantic-release": "17.4.4",
     "svgo": "2.3.1",
     "svgstore": "3.0.0-2",
-    "terser": "5.7.1",
     "text-table": "0.2.0",
     "web-component-analyzer": "1.1.6",
     "webpack-env": "0.8.0",


### PR DESCRIPTION
**Issue**

Closes https://github.com/gravitee-io/gravitee-ui-components/issues/275

**Description**

Minification was causing issues with Webpack 5 and didn't really offer any benefits for users
working with a bundler.


**How to test**

Locally run: 
```sh
# in ui-components
npm run build
cd dist
npm link

# in your app
npm link @gravitee/ui-components
```

