### PR TITLE
fix(gv-code): re-activate clipboard icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24089,8 +24089,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.1",
-            "pacote": "^11.3.0",
+            "npm-package-arg": "^8.1.4",
+            "pacote": "^11.3.4",
             "tar": "^6.1.0"
           }
         },

--- a/src/molecules/gv-code.js
+++ b/src/molecules/gv-code.js
@@ -67,6 +67,7 @@ export class GvCode extends InputElement(LitElement) {
     return {
       ...super.properties,
       options: { type: Object },
+      clipboard: { type: Boolean },
       _clipboardIcon: { type: String },
       _codeMirror: { type: Object },
       rows: { type: Number },
@@ -314,7 +315,7 @@ export class GvCode extends InputElement(LitElement) {
         gv-button {
           position: absolute;
           right: 0;
-          bottom: 0;
+          top: 0;
           z-index: 10;
         }
 


### PR DESCRIPTION
**Description**

Just declare a `clipboard` boolean property

**Additional context**
Useful to replace codemirror in APIM console in the log detail view (gravitee-io/issues#5364)
