### PR TITLE
fix(system-proxy): add system proxy on dynamic properties and diction…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24667,8 +24667,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.1",
-            "pacote": "^11.3.0",
+            "npm-package-arg": "^8.1.4",
+            "pacote": "^11.3.4",
             "tar": "^6.1.0"
           }
         },

--- a/src/policy-studio/gv-policy-studio.js
+++ b/src/policy-studio/gv-policy-studio.js
@@ -48,6 +48,7 @@ const FLOW_STEP_FORM_ID = 'flow-step-form';
  * @attr {Array} services - Services available
  * @attr {Array} resourceTypes - Resources types available
  * @attr {Array} propertyProviders - Providers of properties
+ * @attr {Array} dynamicPropertySchema - Schema for the dynamic property form
  * @attr {String} tabId - Current tabId to display (design, settings, properties or resources)
  * @attr {Object} definition - The definition of flows
  * @attr {Object} documentation - The documentation to display
@@ -70,6 +71,7 @@ export class GvPolicyStudio extends KeyboardElement(LitElement) {
       services: { type: Object },
       resourceTypes: { type: Array, attribute: 'resource-types' },
       propertyProviders: { type: Array, attribute: 'property-providers' },
+      dynamicPropertySchema: { type: Object, attribute: 'dynamic-property-schema' },
       tabId: { type: String, attribute: 'tab-id' },
       _tabId: { type: String, attribute: false },
       definition: { type: Object },
@@ -1704,6 +1706,7 @@ export class GvPolicyStudio extends KeyboardElement(LitElement) {
           ?readonly="${readonlyMode}"
           .properties="${this.definedProperties}"
           .providers="${this.propertyProviders}"
+          .dynamicPropertySchema="${this.dynamicPropertySchema}"
         ></gv-properties>
         <gv-resources
           id="resources"


### PR DESCRIPTION
…nary

**Issue**

https://github.com/gravitee-io/gravitee-ui-components/issues/5910

**Description**

Needed to ensure backward compatibility with v3.5.x on dynamic properties since we moved from trigger (frequency + time unit)  to scheduler (cron expression). Currently the feature is broken.

**Additional context**

I tried, with the help of @gcusnieux, to make the solution still work without modification on version >3.5 of APIM.

