### PR TITLE
Remove Storybook notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "npm run docs && npm run check:i18n && npm run generate:theme && npm run generate:dist && build-storybook -s assets --quiet",
     "check:i18n": "node tasks/check-i18n.js",
     "danger": "danger ci",
-    "docs": "wca analyze src/** --format markdown --outDir .docs && wca analyze src/** --outFile .docs/custom-elements.json && node tasks/generate-docs.js",
+    "docs": "wca analyze src/** --outFile .docs/custom-elements.json && node tasks/generate-docs.js",
     "generate:dist": "node tasks/generate-dist.js",
     "generate:icons": "node tasks/generate-icons.js && npm run lint:fix",
     "generate:theme": "node tasks/generate-theme.js && npm run lint:fix",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "wc"
   ],
   "scripts": {
-    "build": "npm run docs && npm run check:i18n && npm run generate:theme && npm run generate:dist && build-storybook -s assets --quiet",
+    "build": "npm run docs && npm run check:i18n && npm run generate:theme && npm run generate:dist && build-storybook -s assets --modern --quiet",
     "check:i18n": "node tasks/check-i18n.js",
     "danger": "danger ci",
     "docs": "wca analyze src/** --outFile .docs/custom-elements.json && node tasks/generate-docs.js",
@@ -35,8 +35,8 @@
     "prettier": "prettier --check \"**/*.{js,html,css,json}\"",
     "prettier:fix": "prettier --write \"**/*.{js,html,css,json}\"",
     "release": "semantic-release",
-    "serve": "npm run docs && start-storybook -p 6006 --ci -s assets",
-    "serve:prod": "npm run build && static -a 0.0.0.0 -p 8080 storybook-static",
+    "serve": "npm run docs && start-storybook -p 6006 --ci -s assets --modern",
+    "serve:prod": "npm run build && static -a 0.0.0.0 -p 8080 storybook-static --modern",
     "size": "node tasks/size.js",
     "size:dev": "nodemon -w src -x 'npm run generate:dist && npm run size'",
     "test": "jest",

--- a/stories/atoms/gv-autocomplete.stories.js
+++ b/stories/atoms/gv-autocomplete.stories.js
@@ -16,16 +16,12 @@
 import '../../src/atoms/gv-autocomplete';
 import '../../src/atoms/gv-input';
 import '../../src/atoms/gv-image';
-import notes from '../../.docs/gv-autocomplete.md';
 import { makeStory } from '../lib/make-story';
 import picture from '../../assets/images/avatar.png';
 
 export default {
   title: 'Atoms/gv-autocomplete',
   component: 'gv-autocomplete',
-  parameters: {
-    notes,
-  },
 };
 
 const mockVal = (str, repeat = 1) => ({

--- a/stories/atoms/gv-button.stories.js
+++ b/stories/atoms/gv-button.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-button';
-import notes from '../../.docs/gv-button.md';
 import { makeStory } from '../lib/make-story';
 
 const items = [
@@ -41,9 +40,6 @@ const items = [
 export default {
   title: 'Atoms/gv-button',
   component: 'gv-button',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = { component: 'gv-button' };

--- a/stories/atoms/gv-checkbox.stories.js
+++ b/stories/atoms/gv-checkbox.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-checkbox';
-import notes from '../../.docs/gv-checkbox.md';
 import { makeStory } from '../lib/make-story';
 
 const items = [{ innerHTML: 'Default' }, { innerHTML: 'With label', label: 'Default with label' }];
@@ -22,7 +21,6 @@ const items = [{ innerHTML: 'Default' }, { innerHTML: 'With label', label: 'Defa
 export default {
   title: 'Atoms/gv-checkbox',
   component: 'gv-checkbox',
-  parameters: { notes },
 };
 
 const conf = { component: 'gv-checkbox' };

--- a/stories/atoms/gv-date-picker.stories.js
+++ b/stories/atoms/gv-date-picker.stories.js
@@ -15,14 +15,12 @@
  */
 import '../../src/atoms/gv-input';
 import '../../src/atoms/gv-date-picker';
-import notes from '../../.docs/gv-date-picker.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-date-picker',
   component: 'gv-date-picker',
   parameters: {
-    notes,
     // DO NOT REACTIVATE a11y on these stories for now as the a11y checks are taking forever to run
     a11y: { disable: true },
   },

--- a/stories/atoms/gv-file-upload.stories.js
+++ b/stories/atoms/gv-file-upload.stories.js
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-file-upload';
-import notes from '../../.docs/gv-file-upload.md';
 import { makeStory } from '../lib/make-story';
 import img from '../../assets/images/gravitee-logo-white.svg';
 
 export default {
   title: 'Atoms/gv-file-upload',
   component: 'gv-file-upload',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/atoms/gv-icon.stories.js
+++ b/stories/atoms/gv-icon.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-icon';
-import notes from '../../.docs/gv-icon.md';
 import { icons } from '../../.docs/icons.json';
 import { html } from 'lit-html';
 import { styleMap } from 'lit-html/directives/style-map';
@@ -24,7 +23,6 @@ export default {
   title: 'Atoms/gv-icon',
   component: 'gv-icon',
   parameters: {
-    notes,
     // DO NOT REACTIVATE a11y on these stories for now as the a11y checks are taking forever to run
     a11y: { disable: true },
   },

--- a/stories/atoms/gv-image.stories.js
+++ b/stories/atoms/gv-image.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-image';
-import notes from '../../.docs/gv-image.md';
 import '../../src/atoms/gv-icon';
 import logoImage from '../../assets/images/gravitee-logo-cyan.svg';
 import logo from '../../assets/images/gravitee-g-logo-cyan.svg';
@@ -28,7 +27,6 @@ const items = [
 export default {
   title: 'Atoms/gv-image',
   component: 'gv-image',
-  parameters: { notes },
 };
 
 const conf = {

--- a/stories/atoms/gv-input-message.stories.js
+++ b/stories/atoms/gv-input-message.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-input-message';
-import notes from '../../.docs/gv-input-message.md';
 import { makeStory } from '../lib/make-story';
 
 const items = [
@@ -26,9 +25,6 @@ const items = [
 export default {
   title: 'Atoms/gv-input-message',
   component: 'gv-input-message',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = { component: 'gv-input-message' };

--- a/stories/atoms/gv-input.stories.js
+++ b/stories/atoms/gv-input.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-input';
-import notes from '../../.docs/gv-input.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-input',
   component: 'gv-input',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/atoms/gv-link.stories.js
+++ b/stories/atoms/gv-link.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-link';
-import notes from '../../.docs/gv-link.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-link',
   component: 'gv-link',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/atoms/gv-message.stories.js
+++ b/stories/atoms/gv-message.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-message';
-import notes from '../../.docs/gv-message.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-message',
   component: 'gv-message',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/atoms/gv-metric.stories.js
+++ b/stories/atoms/gv-metric.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-metric';
-import notes from '../../.docs/gv-metric.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-metric',
   component: 'gv-metric',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/atoms/gv-relative-time.stories.js
+++ b/stories/atoms/gv-relative-time.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-relative-time';
-import notes from '../../.docs/gv-relative-time.md';
 import { makeStory } from '../lib/make-story';
 
 export function createDateAgo({ seconds = 0, minutes = 0, hours = 0, days = 0, weeks = 0, months = 0, years = 0 }) {
@@ -37,7 +36,7 @@ const STEPS = [1, 5, 10, 20, 30, 45];
 export default {
   title: 'Atoms/gv-relative-time',
   component: 'gv-relative-time',
-  parameters: { notes, chromatic: { disable: true } },
+  parameters: { chromatic: { disable: true } },
   excludeStories: ['createDateAgo'],
 };
 

--- a/stories/atoms/gv-select.stories.js
+++ b/stories/atoms/gv-select.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-select';
-import notes from '../../.docs/gv-select.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-select',
   component: 'gv-select',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/atoms/gv-spinner.stories.js
+++ b/stories/atoms/gv-spinner.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-spinner';
-import notes from '../../.docs/gv-spinner.md';
 import '../../src/atoms/gv-image';
 import { makeStory } from '../lib/make-story';
 
@@ -22,7 +21,6 @@ export default {
   title: 'Atoms/gv-spinner',
   component: 'gv-spinner',
   parameters: {
-    notes,
     chromatic: { disable: true },
   },
 };

--- a/stories/atoms/gv-state.stories.js
+++ b/stories/atoms/gv-state.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-state';
-import notes from '../../.docs/gv-state.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-state',
   component: 'gv-state',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/atoms/gv-switch.stories.js
+++ b/stories/atoms/gv-switch.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-switch';
-import notes from '../../.docs/gv-switch.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-switch',
   component: 'gv-switch',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/atoms/gv-tag.stories.js
+++ b/stories/atoms/gv-tag.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-tag';
-import notes from '../../.docs/gv-tag.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-tag',
   component: 'gv-tag',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/atoms/gv-text.stories.js
+++ b/stories/atoms/gv-text.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/atoms/gv-text';
-import notes from '../../.docs/gv-text.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Atoms/gv-text',
   component: 'gv-text',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/charts/gv-chart-bar.stories.js
+++ b/stories/charts/gv-chart-bar.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-chart-bar.md';
 import '../../src/charts/gv-chart-bar';
 import { makeStory, storyWait } from '../lib/make-story';
 
@@ -39,7 +38,6 @@ export default {
   title: 'charts/gv-chart-bar',
   component: 'gv-chart-bar',
   parameters: {
-    notes,
     chromatic: { disable: true },
   },
 };

--- a/stories/charts/gv-chart-gauge.stories.js
+++ b/stories/charts/gv-chart-gauge.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-chart-gauge.md';
 import '../../src/charts/gv-chart-gauge';
 import { makeStory } from '../lib/make-story';
 
@@ -23,7 +22,6 @@ export default {
   title: 'charts/gv-chart-gauge',
   component: 'gv-chart-gauge',
   parameters: {
-    notes,
     chromatic: { disable: true },
   },
 };

--- a/stories/charts/gv-chart-histogram.stories.js
+++ b/stories/charts/gv-chart-histogram.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-chart-histogram.md';
 import '../../src/charts/gv-chart-histogram';
 import { makeStory, storyWait } from '../lib/make-story';
 
@@ -52,7 +51,6 @@ export default {
   title: 'charts/gv-chart-histogram',
   component: 'gv-chart-histogram',
   parameters: {
-    notes,
     chromatic: { disable: true },
   },
 };

--- a/stories/charts/gv-chart-line.stories.js
+++ b/stories/charts/gv-chart-line.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-chart-line.md';
 import '../../src/charts/gv-chart-line';
 import { makeStory, storyWait } from '../lib/make-story';
 
@@ -60,7 +59,6 @@ export default {
   title: 'charts/gv-chart-line',
   component: 'gv-chart-line',
   parameters: {
-    notes,
     chromatic: { disable: true },
   },
 };

--- a/stories/charts/gv-chart-map.stories.js
+++ b/stories/charts/gv-chart-map.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-chart-map.md';
 import '../../src/charts/gv-chart-map';
 import { makeStory, storyWait } from '../lib/make-story';
 
@@ -59,7 +58,6 @@ export default {
   title: 'charts/gv-chart-map',
   component: 'gv-chart-map',
   parameters: {
-    notes,
     chromatic: { disable: true },
   },
 };

--- a/stories/charts/gv-chart-pie.stories.js
+++ b/stories/charts/gv-chart-pie.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-chart-pie.md';
 import '../../src/charts/gv-chart-pie';
 import { makeStory, storyWait } from '../lib/make-story';
 
@@ -44,7 +43,6 @@ export default {
   title: 'charts/gv-chart-pie',
   component: 'gv-chart-pie',
   parameters: {
-    notes,
     chromatic: { disable: true },
   },
 };

--- a/stories/documentation/gv-theme.stories.js
+++ b/stories/documentation/gv-theme.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-theme.md';
 import '../../src/theme/gv-theme';
 import customElements from '../../.docs/custom-elements.json';
 import { makeStory } from '../lib/make-story';
@@ -21,9 +20,6 @@ import { makeStory } from '../lib/make-story';
 export default {
   title: 'Documentation/Theme',
   component: 'gv-theme',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-card-full.stories.js
+++ b/stories/molecules/gv-card-full.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-card-full.md';
 import '../../src/molecules/gv-card-full';
 import horizontalImage from '../../assets/images/gravitee-logo-cyan.svg';
 import { makeStory, storyWait } from '../lib/make-story';
@@ -42,9 +41,6 @@ const application = Promise.resolve({ name: `${name} app`, description, applicat
 export default {
   title: 'Molecules/gv-card-full',
   component: 'gv-card-full',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-card-list.stories.js
+++ b/stories/molecules/gv-card-list.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-category-list';
-import notes from '../../.docs/gv-category-list.md';
 import { makeStory, storyWait } from '../lib/make-story';
 import horizontalImage from '../../assets/images/gravitee-logo-cyan.svg';
 
@@ -53,9 +52,6 @@ const apiItems = [
 export default {
   title: 'Molecules/gv-card-list',
   component: 'gv-card-list',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-card.stories.js
+++ b/stories/molecules/gv-card.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-card.md';
 import '../../src/molecules/gv-card';
 import horizontalImage from '../../assets/images/gravitee-logo-cyan.svg';
 import logo from '../../assets/images/gravitee-g-logo-cyan.svg';
@@ -23,9 +22,6 @@ import { makeStory, storyWait } from '../lib/make-story';
 export default {
   title: 'Molecules/gv-card',
   component: 'gv-card',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-category-list.stories.js
+++ b/stories/molecules/gv-category-list.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-category-list';
-import notes from '../../.docs/gv-category-list.md';
 import { makeStory, storyWait } from '../lib/make-story';
 import picture from '../../assets/images/avatar.png';
 
@@ -64,7 +63,6 @@ export default {
   title: 'Molecules/gv-category-list',
   component: 'gv-category-list',
   parameters: {
-    notes,
     chromatic: { delay: 2500 },
   },
 };

--- a/stories/molecules/gv-category.stories.js
+++ b/stories/molecules/gv-category.stories.js
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-category';
-import notes from '../../.docs/gv-category.md';
 import { makeStory, storyWait } from '../lib/make-story';
 import picture from '../../assets/images/avatar.png';
 
 export default {
   title: 'Molecules/gv-category',
   component: 'gv-category',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-code.stories.js
+++ b/stories/molecules/gv-code.stories.js
@@ -13,16 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-code.md';
 import '../../src/molecules/gv-code';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'molecules/gv-code',
   component: 'gv-code',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-confirm.stories.js
+++ b/stories/molecules/gv-confirm.stories.js
@@ -15,15 +15,11 @@
  */
 import '../../src/atoms/gv-button';
 import '../../src/molecules/gv-confirm';
-import notes from '../../.docs/gv-confirm.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Molecules/gv-confirm',
   component: 'gv-confirm',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-cron-editor.stories.js
+++ b/stories/molecules/gv-cron-editor.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-cron-editor.md';
 import '../../src/molecules/gv-cron-editor';
 import { makeStory } from '../lib/make-story';
 
@@ -21,7 +20,6 @@ export default {
   title: 'molecules/gv-cron-editor',
   component: 'gv-cron-editor',
   parameters: {
-    notes,
     // DO NOT REACTIVATE a11y on these stories for now as the a11y checks are taking forever to run
     a11y: { disable: true },
   },

--- a/stories/molecules/gv-dropdown-menu.stories.js
+++ b/stories/molecules/gv-dropdown-menu.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-dropdown-menu';
-import notes from '../../.docs/gv-dropdown-menu.md';
 import { makeStory } from '../lib/make-story';
 import '../../src/atoms/gv-button';
 import '../../src/atoms/gv-link';
@@ -22,9 +21,6 @@ import '../../src/atoms/gv-link';
 export default {
   title: 'Molecules/gv-dropdown-menu',
   component: 'gv-dropdown-menu',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-expandable.stories.js
+++ b/stories/molecules/gv-expandable.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import notes from '../../.docs/gv-expandable.md';
 import '../../src/molecules/gv-expandable';
 import { makeStory, storyWait } from '../lib/make-story';
 import mixed from '../resources/schemas/mixed.json';
@@ -26,9 +25,6 @@ const conf = {
 export default {
   title: 'Molecules/gv-expandable',
   ...conf,
-  parameters: {
-    notes,
-  },
 };
 
 export const Basics = makeStory(conf, {

--- a/stories/molecules/gv-expression-language.stories.js
+++ b/stories/molecules/gv-expression-language.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import notes from '../../.docs/gv-expression-language.md';
 import { makeStory } from '../lib/make-story';
 import '../../src/molecules/gv-expression-language';
 import grammar from '../resources/el-grammar.json';
@@ -22,9 +21,6 @@ import grammar from '../resources/el-grammar.json';
 export default {
   title: 'Molecules/gv-expression-language',
   component: 'gv-expression-language',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {
@@ -63,9 +59,9 @@ const groovyOptions = {
   mode: 'groovy',
 };
 
-const groovySrc = `println 'Hello'                                 
+const groovySrc = `println 'Hello'
 
-int power(int n) { 2**n }                       
+int power(int n) { 2**n }
 
 println "2^6==\${power(6)}"`;
 

--- a/stories/molecules/gv-identity-picture.stories.js
+++ b/stories/molecules/gv-identity-picture.stories.js
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-identity-picture';
-import notes from '../../.docs/gv-identity-picture.md';
 import avatar from '../../assets/images/avatar.png';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Molecules/gv-identity-picture',
   component: 'gv-identity-picture',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-list.stories.js
+++ b/stories/molecules/gv-list.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-list.md';
 import '../../src/molecules/gv-list';
 import logo from '../../assets/images/avatar.png';
 import { makeStory, storyWait } from '../lib/make-story';
@@ -26,9 +25,6 @@ const items = [{ item: api1 }, { item: api2 }, { item: api3 }];
 export default {
   title: 'Molecules/gv-list',
   component: 'gv-list',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-metrics.stories.js
+++ b/stories/molecules/gv-metrics.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-metrics';
-import notes from '../../.docs/gv-metrics.md';
 import { makeStory, storyWait } from '../lib/make-story';
 
 export default {
   title: 'Molecules/gv-metrics',
   component: 'gv-metrics',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-modal.stories.js
+++ b/stories/molecules/gv-modal.stories.js
@@ -17,14 +17,12 @@ import '../../src/molecules/gv-modal';
 import '../../src/atoms/gv-input';
 import '../../src/atoms/gv-button';
 import { makeStory } from '../lib/make-story';
-import notes from '../../.docs/gv-modal.md';
 import { html } from 'lit-element';
 
 export default {
   title: 'Molecules/gv-modal',
   component: 'gv-modal',
   parameters: {
-    notes,
     options: {
       showPanel: false,
     },

--- a/stories/molecules/gv-nav.stories.js
+++ b/stories/molecules/gv-nav.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-nav';
-import notes from '../../.docs/gv-nav.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Molecules/gv-nav',
   component: 'gv-nav',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-option.stories.js
+++ b/stories/molecules/gv-option.stories.js
@@ -13,16 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-option.md';
 import '../../src/molecules/gv-option';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Molecules/gv-option',
   component: 'gv-option',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-plans.stories.js
+++ b/stories/molecules/gv-plans.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-plans';
-import notes from '../../.docs/gv-plans.md';
 import { makeStory, storyWait } from '../lib/make-story';
 
 export default {
   title: 'Molecules/gv-plans',
   component: 'gv-plans',
-  parameters: {
-    notes,
-  },
 };
 
 const plans = [

--- a/stories/molecules/gv-popover.stories.js
+++ b/stories/molecules/gv-popover.stories.js
@@ -15,14 +15,12 @@
  */
 import '../../src/atoms/gv-button';
 import '../../src/molecules/gv-popover';
-import notes from '../../.docs/gv-popover.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Molecules/gv-popover',
   component: 'gv-popover',
   parameters: {
-    notes,
     options: {
       showPanel: false,
     },
@@ -38,7 +36,7 @@ const conf = {
       justify-content: space-around;
       align-items: center;
     }
-  
+
     gv-popover {
       border: 1px solid red;
       --gv-popover--bgc: #262626;

--- a/stories/molecules/gv-promote.stories.js
+++ b/stories/molecules/gv-promote.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-promote.md';
 import '../../src/molecules/gv-promote';
 import horizontalImage from '../../assets/images/gravitee-logo-cyan.svg';
 import picture from '../../assets/images/avatar.png';
@@ -39,9 +38,6 @@ const labels = ['APIDays', 'December', 'Foobar'];
 export default {
   title: 'Molecules/gv-promote',
   component: 'gv-promote',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-rating-list.stories.js
+++ b/stories/molecules/gv-rating-list.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-rating-list';
-import notes from '../../.docs/gv-rating-list.md';
 import { makeStory } from '../lib/make-story';
 import avatar from '../../assets/images/avatar.png';
 
@@ -41,9 +40,6 @@ const ratings = [
 export default {
   title: 'Molecules/gv-rating-list',
   component: 'gv-rating-list',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-rating.stories.js
+++ b/stories/molecules/gv-rating.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-rating';
-import notes from '../../.docs/gv-rating.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Molecules/gv-rating',
   component: 'gv-rating',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-row-expandable.stories.js
+++ b/stories/molecules/gv-row-expandable.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import notes from '../../.docs/gv-row-expandable.md';
 import '../../src/molecules/gv-row-expandable';
 import { makeStory } from '../lib/make-story';
 
@@ -25,9 +24,6 @@ const conf = {
 export default {
   title: 'Molecules/gv-row-expandable',
   ...conf,
-  parameters: {
-    notes,
-  },
 };
 
 export const Basics = makeStory(conf, {

--- a/stories/molecules/gv-row.stories.js
+++ b/stories/molecules/gv-row.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-row.md';
 import '../../src/molecules/gv-row';
 import horizontalImage from '../../assets/images/gravitee-logo-cyan.svg';
 import picture from '../../assets/images/avatar.png';
@@ -43,9 +42,6 @@ const api = {
 export default {
   title: 'Molecules/gv-row',
   component: 'gv-row',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-stats.stories.js
+++ b/stories/molecules/gv-stats.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-stats.md';
 import '../../src/molecules/gv-stats';
 import { makeStory, storyWait } from '../lib/make-story';
 
@@ -63,9 +62,6 @@ const options = [
 export default {
   title: 'Molecules/gv-stats',
   component: 'gv-stats',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-stepper.stories.js
+++ b/stories/molecules/gv-stepper.stories.js
@@ -49,6 +49,10 @@ validStep[0].valid = true;
 export const withValidStep = makeStory(conf, {
   items: [{ steps: validStep }],
 });
+withValidStep.parameters = {
+  ...withValidStep.parameters,
+  chromatic: { disable: true },
+};
 
 const validSteps = deepClone(validStep);
 validSteps[1].valid = true;

--- a/stories/molecules/gv-stepper.stories.js
+++ b/stories/molecules/gv-stepper.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-stepper';
-import notes from '../../.docs/gv-stepper.md';
 import { makeStory } from '../lib/make-story';
 import { deepClone } from '../../src/lib/utils';
 
@@ -22,7 +21,6 @@ export default {
   title: 'Molecules/gv-stepper',
   component: 'gv-stepper',
   parameters: {
-    notes,
     chromatic: { delay: 2000 },
   },
 };

--- a/stories/molecules/gv-table.stories.js
+++ b/stories/molecules/gv-table.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-table.md';
 import '../../src/molecules/gv-table';
 import horizontalImage from '../../assets/images/gravitee-logo-cyan.svg';
 import picture from '../../assets/images/avatar.png';
@@ -55,9 +54,6 @@ const application = {
 export default {
   title: 'Molecules/gv-table',
   component: 'gv-table',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/molecules/gv-tree.stories.js
+++ b/stories/molecules/gv-tree.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/molecules/gv-tree';
-import notes from '../../.docs/gv-tree.md';
 import { makeStory } from '../lib/make-story';
 
 const menuItems = [
@@ -50,9 +49,6 @@ const menuItems = [
 export default {
   title: 'Molecules/gv-tree',
   component: 'gv-tree',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/organisms/gv-documentation.stories.js
+++ b/stories/organisms/gv-documentation.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-documentation.md';
 import '../../src/organisms/gv-documentation';
 import content from '../resources/adoc/policy-mock-readme.adoc';
 import { makeStory, storyWait } from '../lib/make-story';
@@ -22,7 +21,6 @@ export default {
   title: 'Organisms/gv-documentation',
   component: 'gv-documentation',
   parameters: {
-    notes,
     options: {
       showPanel: false,
     },

--- a/stories/organisms/gv-header.stories.js
+++ b/stories/organisms/gv-header.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-header.md';
 import '../../src/organisms/gv-header';
 import picture from '../../assets/images/avatar.png';
 import background from '../../assets/images/gravitee-logo-white.svg';
@@ -33,9 +32,6 @@ const itemWithoutPicture = { name: 'Long Supernova', version, states };
 export default {
   title: 'Organisms/gv-header',
   component: 'gv-header',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/organisms/gv-menu.stories.js
+++ b/stories/organisms/gv-menu.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/organisms/gv-menu';
-import notes from '../../.docs/gv-menu.md';
 import horizontalImage from '../../assets/images/gravitee-logo-cyan.svg';
 import { makeStory, storyWait } from '../lib/make-story';
 
@@ -23,9 +22,6 @@ const events = ['gv-link:click', 'gv-input:input', 'gv-input:submit', 'gv-header
 export default {
   title: 'Organisms/gv-menu',
   component: 'gv-menu',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/organisms/gv-newsletter-subscription.stories.js
+++ b/stories/organisms/gv-newsletter-subscription.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/organisms/gv-newsletter-subscription';
-import notes from '../../.docs/gv-newsletter-subscription.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Organisms/gv-newsletter-subscription',
   component: 'gv-newsletter-subscription',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/organisms/gv-pagination.stories.js
+++ b/stories/organisms/gv-pagination.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/organisms/gv-pagination';
-import notes from '../../.docs/gv-pagination.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Organisms/gv-pagination',
   component: 'gv-pagination',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/organisms/gv-properties.stories.js
+++ b/stories/organisms/gv-properties.stories.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 import '../../src/organisms/gv-properties';
-import notes from '../../.docs/gv-properties.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Organisms/gv-properties',
   component: 'gv-properties',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/organisms/gv-resizable-views.stories.js
+++ b/stories/organisms/gv-resizable-views.stories.js
@@ -13,16 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-resizable-views.md';
 import '../../src/organisms/gv-resizable-views';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Organisms/gv-resizable-views',
   component: 'gv-header',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {
@@ -31,7 +27,7 @@ const conf = {
     :host {
       height: 100vh;
     }
-    
+
     .content {
       padding: 0 0.5rem;
       box-sizing: border-box;

--- a/stories/organisms/gv-resources.stories.js
+++ b/stories/organisms/gv-resources.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/organisms/gv-resources';
-import notes from '../../.docs/gv-resources.md';
 import { makeStory } from '../lib/make-story';
 
 import apimResourceTypes from '../resources/apim-resource-types.json';
@@ -24,7 +23,6 @@ export default {
   title: 'organisms/gv-resources',
   component: 'gv-resources',
   parameters: {
-    notes,
     options: {
       showPanel: false,
     },

--- a/stories/organisms/gv-schema-form.stories.js
+++ b/stories/organisms/gv-schema-form.stories.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import notes from '../../.docs/gv-schema-form.md';
 import '../../src/organisms/gv-schema-form';
 import { makeStory } from '../lib/make-story';
 import mixed from '../resources/schemas/mixed.json';
@@ -25,7 +24,6 @@ export default {
   title: 'organisms/gv-schema-form',
   component: 'gv-schema-form',
   parameters: {
-    notes,
     // DO NOT REACTIVATE a11y on these stories for now as the a11y checks are taking forever to run
     a11y: { disable: true },
   },

--- a/stories/organisms/gv-tabs.stories.js
+++ b/stories/organisms/gv-tabs.stories.js
@@ -15,15 +15,11 @@
  */
 import '../../src/organisms/gv-tabs';
 import '../../src/atoms/gv-button';
-import notes from '../../.docs/gv-tabs.md';
 import { makeStory } from '../lib/make-story';
 
 export default {
   title: 'Organisms/gv-tabs',
   component: 'gv-tabs',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/organisms/gv-user-menu.stories.js
+++ b/stories/organisms/gv-user-menu.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/organisms/gv-user-menu';
-import notes from '../../.docs/gv-user-menu.md';
 import bigImage from '../../assets/images/gravitee-logo-cyan.svg';
 import avatarSrc from '../../assets/images/avatar.png';
 import { makeStory, storyWait } from '../lib/make-story';
@@ -31,9 +30,6 @@ const routes = [
 export default {
   title: 'Organisms/gv-user-menu',
   component: 'gv-user-menu',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/organisms/gv-vertical-menu.stories.js
+++ b/stories/organisms/gv-vertical-menu.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/organisms/gv-vertical-menu';
-import notes from '../../.docs/gv-vertical-menu.md';
 import { makeStory } from '../lib/make-story';
 import logo from '../../assets/images/gravitee-g-logo-cyan.svg';
 
@@ -23,9 +22,6 @@ const events = ['gv-link:click', 'gv-input:input', 'gv-input:submit', 'gv-header
 export default {
   title: 'Organisms/gv-vertical-menu',
   component: 'gv-vertical-menu',
-  parameters: {
-    notes,
-  },
 };
 
 const conf = {

--- a/stories/policy-studio/gv-policy-studio.stories.js
+++ b/stories/policy-studio/gv-policy-studio.stories.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import '../../src/policy-studio/gv-policy-studio';
-import notes from '../../.docs/gv-policy-studio.md';
 import { makeStory } from '../lib/make-story';
 
 import apimPolicies from '../resources/apim-policies.json';
@@ -33,7 +32,6 @@ export default {
   title: 'Policy Studio/gv-policy-studio',
   component: 'gv-policy-studio',
   parameters: {
-    notes,
     options: {
       showPanel: false,
     },

--- a/tasks/generate-theme.js
+++ b/tasks/generate-theme.js
@@ -21,7 +21,6 @@ const rawGlob = require('glob');
 const util = require('util');
 const glob = util.promisify(rawGlob);
 const wca = require('web-component-analyzer');
-const filepath = '.docs/custom-properties.md';
 const themeFilepath = 'src/theme/definition.json';
 const cssFilepath = 'assets/css/gravitee-theme.generated.css';
 
@@ -54,12 +53,10 @@ async function run() {
     ignore: ['./src/lib/*.js', './src/styles/*.js', './src/studio-policy/*.js'],
   });
 
-  await del([filepath, themeFilepath, cssFilepath]);
+  await del([themeFilepath, cssFilepath]);
 
-  const input = [];
   let gvTheme;
   let themableElements = [];
-  let index = 1;
   for (const src of sourceFilepaths) {
     const code = await fs.readFile(src, 'utf8');
     const { results, program } = wca.analyzeText(code, { config: { features: ['cssproperty'] } });
@@ -116,10 +113,6 @@ async function run() {
             throw new Error(`${tag.name} | ${cssProperty.name} should have Length type`);
           }
         });
-        const doc = wca.transformAnalyzerResult('markdown', results, program);
-        const markdownProperties = doc.split('## CSS Custom Properties')[1];
-        input.push(`# ${index++}. ${tag.name}`);
-        input.push(markdownProperties);
         themableElements = themableElements.concat(tag);
       } else {
         console.warn(`warning: ${tag.name} doesn't have css properties ?`);
@@ -158,7 +151,6 @@ async function run() {
   delete gvTheme.cssProperties;
 
   await fs.appendFile(themeFilepath, JSON.stringify({ data: [gvTheme].concat(gvComponents) }, null, 2));
-  await fs.appendFile(filepath, input.join('\n'));
 }
 
 run().catch(console.error);


### PR DESCRIPTION
**Issue**

NA

**Description**

 - Remove Storybook notes as it is now included by default in addon-docs. To check everything is still working take a look at the doc pages of this PR's Storybook:  https://5ffff84833d7150021078521-bvaggdgmro.chromatic.com/?path=/docs/atoms-gv-button--modes
 - Build Storybook with `--modern` flag to reduce build size

