### PR TITLE
fix(gv-policy-studio): use correct icon and name for `try it` tab

### DIFF
--- a/src/policy-studio/gv-policy-studio.js
+++ b/src/policy-studio/gv-policy-studio.js
@@ -376,7 +376,7 @@ export class GvPolicyStudio extends KeyboardElement(LitElement) {
 
   set canDebug(value) {
     if (value) {
-      this._tabs = [...this._tabs, { id: 'debug', title: 'Try it?', icon: 'general:settings#2' }];
+      this._tabs = [...this._tabs, { id: 'debug', title: 'Try it', icon: 'content:send' }];
     }
   }
 


### PR DESCRIPTION
**Issue**

NA

**Description**

Before
![image](https://user-images.githubusercontent.com/4112568/129529935-d4a736f6-4f87-4172-8f0a-325f29d839a9.png)

After
![image](https://user-images.githubusercontent.com/4112568/129529908-437b5076-e656-41df-b286-1d18bbd95322.png)

