### PR TITLE
feat(gv-schema-form): add simple hidden field support

### DIFF
--- a/src/organisms/gv-schema-form-control.js
+++ b/src/organisms/gv-schema-form-control.js
@@ -341,7 +341,11 @@ export class GvSchemaFormControl extends LitElement {
         }
 
         :host([hidden]) {
-          display: none;
+          visibility: hidden;
+          height: 0;
+          margin: 0;
+          padding: 0;
+          overflow: hidden;
         }
 
         .form__control-description,

--- a/src/organisms/gv-schema-form.js
+++ b/src/organisms/gv-schema-form.js
@@ -276,6 +276,7 @@ export class GvSchemaForm extends LitElement {
     for (const operation of condition) {
       // operation only have one operator with a single object containing operand values
       const operator = Object.keys(operation)[0];
+
       switch (operator) {
         case '$neq':
           result = result && this._evaluateNotEqualsCondition(operation);
@@ -306,9 +307,13 @@ export class GvSchemaForm extends LitElement {
   _evaluateEqualsCondition(condition) {
     const operator = Object.keys(condition)[0];
     const operands = condition[operator];
-    const modelAttribute = Object.keys(operands)[0];
-    const testValue = operands[modelAttribute];
-    return get(this._values, modelAttribute) === testValue;
+    const modelAttributes = Object.keys(operands);
+    return modelAttributes
+      .map((modelAttribute) => {
+        const testValue = operands[modelAttribute];
+        return get(this._values, modelAttribute) === testValue;
+      })
+      .reduce((acc, current) => acc || current);
   }
 
   _evaluateNotDefCondition(condition) {

--- a/src/organisms/gv-schema-form.js
+++ b/src/organisms/gv-schema-form.js
@@ -263,6 +263,9 @@ export class GvSchemaForm extends LitElement {
       return false;
     }
     const condition = control['x-schema-form'][conditionKey];
+    if (typeof condition === 'boolean') {
+      return condition;
+    }
     if (!Array.isArray(condition)) {
       // condition isn't an array, ignore the condition
       console.warn(`'${conditionKey}' attribute of 'x-schema-form' should be an array`);

--- a/stories/organisms/gv-schema-form.test.js
+++ b/stories/organisms/gv-schema-form.test.js
@@ -48,6 +48,7 @@ describe('S C H E M A  F O R M', () => {
     'multiselect',
     'cron',
     'disabled',
+    'hidden-with-condition',
     'hidden',
     'readonly',
     'writeonly',
@@ -113,6 +114,7 @@ describe('S C H E M A  F O R M', () => {
       attributes: [{ name: 'foo', value: 'bar' }],
       cron: '*/30 * * * * SUN-MON',
       disabled: 'Simple Test',
+      hidden: 'not visible',
     };
     component.requestUpdate();
 
@@ -133,6 +135,7 @@ describe('S C H E M A  F O R M', () => {
         checkControl('attributes.0', { value: { name: 'foo', value: 'bar' } });
         checkControl('cron', { value: '*/30 * * * * SUN-MON' });
         checkControl('disabled', { value: 'Simple Test' });
+        checkControl('hidden', { value: 'not visible', hidden: true });
         done();
       }, 0);
     });

--- a/stories/resources/schemas/mixed.json
+++ b/stories/resources/schemas/mixed.json
@@ -151,7 +151,7 @@
         "disabled": [{ "$def": "select" }, { "$eq": { "select": "a" } }]
       }
     },
-    "hidden": {
+    "hidden-with-condition": {
       "title": "Hidden field if 'Simple select' is 'a'",
       "type": "string",
       "x-schema-form": {
@@ -165,6 +165,13 @@
             }
           }
         ]
+      }
+    },
+    "hidden": {
+      "title": "Hidden field",
+      "type": "string",
+      "x-schema-form": {
+        "hidden": true
       }
     },
     "readonly": {


### PR DESCRIPTION
Some improvements of `gv-schema-form` component.

The goal is to have more possibility for hide some fields.

Related to gravitee-io/issues#5948 and gravitee-io/issues#5972
