### PR TITLE
Fix icon display in app using AngularJS

### DIFF
--- a/src/atoms/gv-icon.js
+++ b/src/atoms/gv-icon.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { css, LitElement, html } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { Directive, directive } from 'lit/directive';
 
 import { classMap } from 'lit/directives/class-map';
@@ -94,9 +94,9 @@ export class GvIcon extends LitElement {
   }
 
   render() {
-    const xlinkNamespace = 'http://www.w3.org/1999/xlink';
+    const namespacedHref = namespaced('http://www.w3.org/1999/xlink', GvIcon.getHref(this.shape));
     return html`<svg class="${classMap({ 'no-color': !this.canCustomize() })}">
-      <use xlink:href="${namespaced(xlinkNamespace, GvIcon.getHref(this.shape))}" />
+      <use xlink:href="${namespacedHref}" />
     </svg>`;
   }
 }


### PR DESCRIPTION

**Description**

After the update to Lit 2 and due to miscellaneous reasons `gv-icon` weren't display in AngularJS app anymore.

Some investigations put in light the Namespaced was not called properly anymore. See the `xlink:href` attribute:
<img width="748" alt="Capture d’écran 2021-10-07 à 13 40 33" src="https://user-images.githubusercontent.com/4112568/136377910-86205ab3-e1bf-47e2-8ebb-96ce1db6ab74.png">

Moving the directive call out the template string make it work again. 

<img width="758" alt="Capture d’écran 2021-10-07 à 13 37 27" src="https://user-images.githubusercontent.com/4112568/136378005-cb7eb00f-1a7d-45a5-a538-aa5921128bc6.png">

Why not...

Also, everything was still working fine for Angular and Lit apps.

🤷🏻 
