### PR TITLE
Update `commitlint` configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [1, 'always', 100],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -43,11 +43,6 @@
     "test:coverage": "npm run test -- --collect-coverage",
     "test:watch": "npm run test -- --watchAll"
   },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
-  },
   "lint-staged": {
     "*": "npm run lint:license:fix",
     "*.{js,html,css,json}": "prettier --write",


### PR DESCRIPTION
**Description**

Move `commitlint` config in a dedicated file and update body line max length rule

Previously the body of a commit shouldn't be longer than 100 characters, it was causing problems with PR opened by Snyk so I update this rule to be a warning only.
