### PR TITLE
fix(gv-input): click on search icon should submit in gv-input

### DIFF
--- a/src/atoms/gv-input.js
+++ b/src/atoms/gv-input.js
@@ -422,13 +422,8 @@ export class GvInput extends InputElement(LitElement) {
   }
 
   _onIconClick() {
-    if (this._type === 'search') {
-      this.value = '';
-      dispatchCustomEvent(this, 'input', this.value);
-    } else {
-      dispatchCustomEvent(this, 'icon-click', this.value);
-      dispatchCustomEvent(this, 'submit', this.value);
-    }
+    dispatchCustomEvent(this, 'icon-click', this.value);
+    dispatchCustomEvent(this, 'submit', this.value);
   }
 
   _onIconVisibleClick(e) {


### PR DESCRIPTION
**Issue**

gravitee-io/issues#5323

**Description**

Clicking on search icon in gv-input made a reset of the value and trigger the 'input' event.
Fix it to have the same behavior as an icon click: 'submit'


