### PR TITLE
gv-code: define extension of files to load for a specific CodeMirror mode

### DIFF
--- a/src/molecules/gv-code.js
+++ b/src/molecules/gv-code.js
@@ -114,9 +114,9 @@ export class GvCode extends InputElement(LitElement) {
         if (options.mode != null) {
           const mode = typeof options.mode === 'string' ? options.mode : options.mode.name;
           if (mode === 'asciidoc') {
-            await import('codemirror-asciidoc/lib/asciidoc');
+            await import('codemirror-asciidoc/lib/asciidoc.js');
           } else {
-            await import(`codemirror/mode/${mode}/${mode}`);
+            await import(`codemirror/mode/${mode}/${mode}.js`);
           }
         }
       } catch (er) {}


### PR DESCRIPTION
**Issue**

NA

**Description**

Define the extension of files to load for a specific CodeMirror mode

An import without a file extension is making webpack (or any other bundler) trying to require all the files matching the name. Everything is ok with modes containing only a JS file in their folder.

But a few of them also have CSS or HTML files causing issues when the bundler is trying to load them.

Using the JS extension ensure we are only loading the file we have in mind.
