### PR TITLE
Clean after upgrade to lit2

### DIFF
--- a/src/atoms/gv-select-native.js
+++ b/src/atoms/gv-select-native.js
@@ -182,7 +182,7 @@ export class GvSelectNative extends InputElement(LitElement) {
   }
 
   getInputElement() {
-    return super.getInputElement();
+    return this.shadowRoot.querySelector('select');
   }
 
   async firstUpdated(changedProperties) {

--- a/src/atoms/gv-select-native.js
+++ b/src/atoms/gv-select-native.js
@@ -17,7 +17,7 @@ import { classMap } from 'lit/directives/class-map';
 import { ifDefined } from 'lit/directives/if-defined';
 import { repeat } from 'lit/directives/repeat';
 
-import { LitElement, html, css } from 'lit';
+import { css, html, LitElement } from 'lit';
 import { skeleton } from '../styles/skeleton';
 import { link } from '../styles/link';
 import { input } from '../styles/input';
@@ -59,7 +59,6 @@ export class GvSelectNative extends InputElement(LitElement) {
       medium: { type: Boolean },
       small: { type: Boolean },
       value: { type: String | Array },
-      _value: { type: String | Array, attribute: false },
       label: { type: String },
       title: { type: String },
       name: { type: String },
@@ -201,24 +200,10 @@ export class GvSelectNative extends InputElement(LitElement) {
     }
   }
 
-  set value(value) {
-    if (this.multiple) {
-      if (value == null) {
-        this._value = null;
-        this.updateState(this._value);
-      }
-      if (Array.isArray(value)) {
-        this._value = value;
-        this.updateState(this._value);
-      }
-    } else {
-      this._value = value;
-      this.updateState(this._value);
+  willUpdate(changedProperties) {
+    if (changedProperties.has('value')) {
+      this.updateState(changedProperties.get('value'));
     }
-  }
-
-  get value() {
-    return this._value;
   }
 
   updateState(value) {

--- a/src/atoms/gv-select.js
+++ b/src/atoms/gv-select.js
@@ -66,7 +66,6 @@ export class GvSelect extends withResizeObserver(InputElement(LitElement)) {
       medium: { type: Boolean },
       small: { type: Boolean },
       value: { type: String | Array },
-      _value: { type: String | Array, attribute: false },
       label: { type: String },
       title: { type: String },
       name: { type: String },
@@ -238,24 +237,10 @@ export class GvSelect extends withResizeObserver(InputElement(LitElement)) {
     super.disconnectedCallback();
   }
 
-  set value(value) {
-    if (this.multiple) {
-      if (value == null) {
-        this._value = null;
-        this.updateState(this._value);
-      }
-      if (Array.isArray(value)) {
-        this._value = value;
-        this.updateState(this._value);
-      }
-    } else {
-      this._value = value;
-      this.updateState(this._value);
+  willUpdate(changedProperties) {
+    if (changedProperties.has('value')) {
+      this.updateState(changedProperties.get('value'));
     }
-  }
-
-  get value() {
-    return this._value;
   }
 
   updateState(value) {

--- a/src/organisms/gv-schema-form.js
+++ b/src/organisms/gv-schema-form.js
@@ -287,7 +287,6 @@ export class GvSchemaForm extends LitElement {
     const isWriteOnly = control.writeOnly === true;
     const value = get(this._values, key);
     return html`<gv-schema-form-control
-      data-a="dd"
       .id="${key}"
       .errors="${this.errors}"
       .control="${control}"

--- a/src/organisms/gv-schema-form.js
+++ b/src/organisms/gv-schema-form.js
@@ -158,7 +158,8 @@ export class GvSchemaForm extends LitElement {
     const { resolve } = this._confirm;
     this._confirm = null;
     this._onReset();
-    this.requestUpdate().then(() => {
+    this.requestUpdate();
+    this.updateComplete.then(() => {
       resolve(this);
     });
   }
@@ -268,6 +269,7 @@ export class GvSchemaForm extends LitElement {
   }
 
   async performUpdate() {
+    await Promise.all(this.getControls().map((e) => e.updateComplete));
     this.getControls().forEach((s) => {
       s.requestUpdate();
     });
@@ -394,7 +396,11 @@ export class GvSchemaForm extends LitElement {
     }
     const keys = this.schema.properties ? Object.keys(this.schema.properties) : [];
     this._ignoreProperties = [];
-    return repeat(keys, (key) => this._renderControl(key));
+    return repeat(
+      keys,
+      (key) => key,
+      (key) => this._renderControl(key),
+    );
   }
 
   getControls() {
@@ -485,8 +491,9 @@ export class GvSchemaForm extends LitElement {
   }
 
   async getUpdateComplete() {
-    await super.getUpdateComplete();
+    const result = await super.getUpdateComplete();
     await Promise.all(this.getControls().map((e) => e.updateComplete));
+    return result;
   }
 
   render() {

--- a/stories/charts/gv-chart-pie.stories.js
+++ b/stories/charts/gv-chart-pie.stories.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import '../../src/charts/gv-chart-pie';
-import { makeStory, storyWait } from '../lib/make-story';
+import { makeStory } from '../lib/make-story';
+import { wait } from '../lib/sequence';
 
 const events = ['gv-chart-pie:select'];
 
@@ -65,31 +66,26 @@ export const Empty = makeStory(conf, {
   items: [{ series: [], options }],
 });
 
-let seriesResolver;
 export const Loading = makeStory(conf, {
   items: [{}],
-  simulations: [
-    storyWait(0, ([component]) => {
-      component.series = new Promise((resolve) => (seriesResolver = resolve));
-      component.options = options;
-    }),
+  play: async ({ component }) => {
+    let seriesResolver;
+    component.series = new Promise((resolve) => (seriesResolver = resolve));
+    component.options = options;
 
-    storyWait(750, () => {
-      seriesResolver(series);
-    }),
-  ],
+    await wait(750);
+    seriesResolver(series);
+  },
 });
 
 export const LoadingAndError = makeStory(conf, {
   items: [{}],
-  simulations: [
-    storyWait(0, ([component]) => {
-      component.series = new Promise((resolve, reject) => (seriesResolver = reject));
-      component.options = options;
-    }),
+  play: async ({ component }) => {
+    let seriesResolver;
+    component.series = new Promise((resolve, reject) => (seriesResolver = reject));
+    component.options = options;
 
-    storyWait(750, () => {
-      seriesResolver({});
-    }),
-  ],
+    await wait(750);
+    seriesResolver({});
+  },
 });

--- a/stories/lib/make-story.js
+++ b/stories/lib/make-story.js
@@ -32,7 +32,7 @@ export function makeStory(...configs) {
 
   const items = typeof rawItems === 'function' ? rawItems() : rawItems;
 
-  const storyFn = (args) => {
+  const storyRenderFn = (args) => {
     const container = document.createElement('div');
     const shadow = container.attachShadow({ mode: 'open' });
 
@@ -99,21 +99,24 @@ export function makeStory(...configs) {
       })
       .join('\n');
 
-  storyFn.docs = docs;
-  storyFn.css = css;
-  storyFn.component = component;
-  storyFn.items = items;
-  storyFn.parameters = {
-    actions: {
-      handles: [..._events],
+  const story = {
+    docs,
+    css,
+    component,
+    items,
+    parameters: {
+      actions: {
+        handles: [..._events],
+      },
+      docsOnly,
+      docs: {
+        storyDescription: (docs || '').trim(),
+      },
+      storySource: {
+        source: generatedSource(),
+      },
     },
-    docsOnly,
-    docs: {
-      storyDescription: (docs || '').trim(),
-    },
-    storySource: {
-      source: generatedSource(),
-    },
+    render: storyRenderFn,
   };
 
   // Disable Chromatic for stories with `skeleton` or `loading` properties or
@@ -124,7 +127,7 @@ export function makeStory(...configs) {
   const automaticallyDisableChromatic = simulations.length > 0 || hasItemWithLoadingAttribute || hasItemWithSkeletonAttribute;
 
   if (automaticallyDisableChromatic === true) {
-    storyFn.parameters.chromatic = { disable: automaticallyDisableChromatic };
+    story.parameters.chromatic = { disable: automaticallyDisableChromatic };
   }
 
   const argTypes = {};
@@ -160,12 +163,12 @@ export function makeStory(...configs) {
     });
   }
 
-  storyFn.argTypes = argTypes;
+  story.argTypes = argTypes;
   if (name != null) {
-    storyFn.name = name;
+    story.name = name;
   }
 
-  return storyFn;
+  return story;
 }
 
 export function storyWait(delay, callback) {

--- a/stories/lib/make-story.js
+++ b/stories/lib/make-story.js
@@ -26,6 +26,7 @@ export function makeStory(...configs) {
     events = [],
     simulations = [],
     docsOnly = false,
+    play,
   } = Object.assign({}, ...configs);
   const customElement = customElements.tags.find((tag) => tag.name === component) || {};
   const _events = customElement.events ? [...new Set([...events, ...customElement.events.map((e) => e.name)])] : events;
@@ -118,6 +119,13 @@ export function makeStory(...configs) {
     },
     render: storyRenderFn,
   };
+
+  if (play) {
+    story.play = async (context) => {
+      const element = context.canvasElement.querySelector('div').shadowRoot.querySelector(component);
+      await play({ context, component: element });
+    };
+  }
 
   // Disable Chromatic for stories with `skeleton` or `loading` properties or
   // with async process using `simulations` fields. Otherwise there are some

--- a/stories/lib/make-story.js
+++ b/stories/lib/make-story.js
@@ -22,7 +22,6 @@ export function makeStory(...configs) {
     docs,
     css,
     component,
-    dom,
     items: rawItems = [{}],
     events = [],
     simulations = [],
@@ -43,12 +42,6 @@ export function makeStory(...configs) {
       shadow.appendChild(styles);
     }
 
-    if (dom != null) {
-      const wrapper = document.createElement('div');
-      shadow.appendChild(wrapper);
-      dom(wrapper);
-      return container;
-    }
     const items = typeof rawItems === 'function' ? rawItems() : rawItems;
 
     const components = items.map((props) => {
@@ -106,14 +99,6 @@ export function makeStory(...configs) {
       })
       .join('\n');
 
-  const domSource = () => {
-    const container = document.createElement('div');
-    dom(container);
-    return container.innerHTML.replace(/<!---->/g, '').trim();
-  };
-
-  const mdxSource = dom != null ? domSource() : generatedSource();
-
   storyFn.docs = docs;
   storyFn.css = css;
   storyFn.component = component;
@@ -127,7 +112,7 @@ export function makeStory(...configs) {
       storyDescription: (docs || '').trim(),
     },
     storySource: {
-      source: mdxSource,
+      source: generatedSource(),
     },
   };
 

--- a/stories/lib/sequence.js
+++ b/stories/lib/sequence.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-function wait(delay) {
+export function wait(delay) {
   return new Promise((resolve) => {
     setTimeout(resolve, delay);
   });

--- a/stories/organisms/gv-schema-form.test.js
+++ b/stories/organisms/gv-schema-form.test.js
@@ -26,11 +26,12 @@ describe('S C H E M A  F O R M', () => {
   let page;
   let component;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     page = new Page();
     component = page.create('gv-schema-form', {
       schema: mixed,
     });
+    await component.updateComplete;
   });
 
   afterEach(() => {
@@ -81,28 +82,27 @@ describe('S C H E M A  F O R M', () => {
     });
   };
 
-  test('should create element', (done) => {
+  test('should create element', async () => {
     expect(window.customElements.get('gv-schema-form')).toBeDefined();
     expect(component).toEqual(querySelector('gv-schema-form'));
 
-    component.updateComplete.then(() => {
-      expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+    await component.updateComplete;
 
-      checkControl('body');
-      checkControl('el');
-      checkControl('body-with-el');
-      checkControl('path-operator');
-      checkControl('resources');
-      checkControl('timeToLiveSeconds');
-      checkControl('useResponseCacheHeaders');
-      checkControl('select');
-      checkControl('multiselect');
-      checkControl('whitelist');
-      done();
-    });
+    expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+
+    checkControl('body');
+    checkControl('el');
+    checkControl('body-with-el');
+    checkControl('path-operator');
+    checkControl('resources');
+    checkControl('timeToLiveSeconds');
+    checkControl('useResponseCacheHeaders');
+    checkControl('select');
+    checkControl('multiselect');
+    checkControl('whitelist');
   });
 
-  test('should create element with valid values', (done) => {
+  test('should create element with valid values', async () => {
     component.values = {
       body: '<xml>foobar</xml>',
       el: `{#request.headers['Content-Type'][0].toString()}`,
@@ -121,72 +121,62 @@ describe('S C H E M A  F O R M', () => {
       disabled: 'Simple Test',
       hidden: 'not visible',
     };
+
     component.requestUpdate();
+    await component.updateComplete;
 
-    component.updateComplete.then(() => {
-      setTimeout(() => {
-        expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+    expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
 
-        checkControl('body', { value: '<xml>foobar</xml>' });
-        checkControl('path-operator', { value: { operator: 'EQUALS', path: '/foobar' } });
-        checkControl('path-operator.path', { value: '/foobar' });
-        checkControl('path-operator.operator', { value: 'EQUALS' });
-        checkControl('resources', { value: 'my-resource' });
-        checkControl('timeToLiveSeconds', { value: 50 });
-        checkControl('useResponseCacheHeaders', {});
-        checkControl('select', { value: 'b' });
-        checkControl('multiselect', { value: ['a', 'b', 'c'] });
-        checkControl('attributes', { value: [{ name: 'foo', value: 'bar' }] });
-        checkControl('attributes.0', { value: { name: 'foo', value: 'bar' } });
-        checkControl('cron', { value: '*/30 * * * * SUN-MON' });
-        checkControl('disabled', { value: 'Simple Test' });
-        checkControl('hidden', { value: 'not visible', hidden: true });
-        checkControl('whitelist', {});
-        done();
-      }, 0);
-    });
+    checkControl('body', { value: '<xml>foobar</xml>' });
+    checkControl('path-operator', { value: { operator: 'EQUALS', path: '/foobar' } });
+    checkControl('path-operator.path', { value: '/foobar' });
+    checkControl('path-operator.operator', { value: 'EQUALS' });
+    checkControl('resources', { value: 'my-resource' });
+    checkControl('timeToLiveSeconds', { value: 50 });
+    checkControl('useResponseCacheHeaders', {});
+    checkControl('select', { value: 'b' });
+    checkControl('multiselect', { value: ['a', 'b', 'c'] });
+    checkControl('attributes', { value: [{ name: 'foo', value: 'bar' }] });
+    checkControl('attributes.0', { value: { name: 'foo', value: 'bar' } });
+    checkControl('cron', { value: '*/30 * * * * SUN-MON' });
+    checkControl('disabled', { value: 'Simple Test' });
+    checkControl('hidden', { value: 'not visible', hidden: true });
+    checkControl('whitelist', {});
   });
 
-  test('should disable element if "select" is "a"', (done) => {
+  test('should disable element if "select" is "a"', async () => {
     component.values = {
       select: 'a',
       disabled: 'Simple Test',
     };
     component.requestUpdate();
 
-    component.updateComplete.then(() => {
-      setTimeout(() => {
-        expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+    await component.updateComplete;
 
-        checkControl('disabled', { value: 'Simple Test' });
+    expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
 
-        expect(component.getControl('disabled').disabled).toBeTruthy();
-        done();
-      }, 0);
-    });
+    checkControl('disabled', { value: 'Simple Test' });
+
+    expect(component.getControl('disabled').disabled).toBeTruthy();
   });
 
-  test('should not disable element if "select" is not "a"', (done) => {
+  test('should not disable element if "select" is not "a"', async () => {
     component.values = {
       select: 'b',
       disabled: 'Simple Test',
     };
     component.requestUpdate();
 
-    component.updateComplete.then(() => {
-      setTimeout(() => {
-        expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+    await component.updateComplete;
 
-        checkControl('disabled', { value: 'Simple Test' });
+    expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
 
-        expect(component.getControl('disabled').disabled).toBeFalsy();
+    checkControl('disabled', { value: 'Simple Test' });
 
-        done();
-      }, 0);
-    });
+    expect(component.getControl('disabled').disabled).toBeFalsy();
   });
 
-  test('should create element with invalid values', (done) => {
+  test('should create element with invalid values', async () => {
     component.values = {
       body: '<xml></xml>',
       'path-operator': {
@@ -201,23 +191,20 @@ describe('S C H E M A  F O R M', () => {
       attributes: [{ name: 'foo', value: '' }, {}],
     };
 
-    component.updateComplete.then(() => {
-      setTimeout(() => {
-        checkControl('body', { value: '<xml></xml>' });
-        checkControl('path-operator', { value: { operator: 'Fake value', path: 'not a path' } });
-        checkControl('path-operator.path', { value: 'not a path' });
-        checkControl('path-operator.operator', { value: 'Fake value' });
-        checkControl('resources', { value: 'my-resource' });
-        checkControl('timeToLiveSeconds', { value: 'not number' });
-        checkControl('useResponseCacheHeaders', {});
-        checkControl('select', { value: 'b' });
-        checkControl('multiselect', { value: ['a', 'b', 'c'] });
-        checkControl('attributes', { value: [{ name: 'foo', value: '' }, {}] });
-        checkControl('attributes.0', { value: { name: 'foo', value: '' } });
-        checkControl('attributes.1', { value: {} });
-        done();
-      }, 0);
-    });
+    await component.updateComplete;
+
+    checkControl('body', { value: '<xml></xml>' });
+    checkControl('path-operator', { value: { operator: 'Fake value', path: 'not a path' } });
+    checkControl('path-operator.path', { value: 'not a path' });
+    checkControl('path-operator.operator', { value: 'Fake value' });
+    checkControl('resources', { value: 'my-resource' });
+    checkControl('timeToLiveSeconds', { value: 'not number' });
+    checkControl('useResponseCacheHeaders', {});
+    checkControl('select', { value: 'b' });
+    checkControl('multiselect', { value: ['a', 'b', 'c'] });
+    checkControl('attributes', { value: [{ name: 'foo', value: '' }, {}] });
+    checkControl('attributes.0', { value: { name: 'foo', value: '' } });
+    checkControl('attributes.1', { value: {} });
   });
 
   test('should update values & dirty state when user change the form', () => {


### PR DESCRIPTION
**Issue**

NA

**Description**

1. Some fixes after upgrade to Lit 2
 - revert unneeded changed introduced in upgrade to Lit 2 
 - wait for Lit component to be ready before updating their properties
 - replace getter/setter with `willUpdate` function to follow: https://lit.dev/docs/components/properties/#accessors-custom
> In most cases, you do not need to create custom property accessors. To compute values from existing properties, we recommend using the willUpdate callback, which allows you to set values during the update cycle without triggering an additional update. To perform a custom action after the element updates, we recommend using the updated callback. A custom setter can be used in rare cases when it's important to synchronously validate any value the user sets.

2. Improvements related to Storybook
 - remove dom parameter from makeStory as it is not used anymore
 - use new Story format (Csf V3) during story generation
 - add support for play function in stories ⏯
