### PR TITLE
 fix: resolve will update implementation 

### DIFF
--- a/src/atoms/gv-select-native.js
+++ b/src/atoms/gv-select-native.js
@@ -202,7 +202,7 @@ export class GvSelectNative extends InputElement(LitElement) {
 
   willUpdate(changedProperties) {
     if (changedProperties.has('value')) {
-      this.updateState(changedProperties.get('value'));
+      this.updateState(this.value);
     }
   }
 

--- a/src/atoms/gv-select.js
+++ b/src/atoms/gv-select.js
@@ -239,7 +239,7 @@ export class GvSelect extends withResizeObserver(InputElement(LitElement)) {
 
   willUpdate(changedProperties) {
     if (changedProperties.has('value')) {
-      this.updateState(changedProperties.get('value'));
+      this.updateState(this.value);
     }
   }
 


### PR DESCRIPTION
In Lit 2 documentation,
**willUpdate()**
`changedProperties`:`Map` with keys that are the names of changed properties and values that are the corresponding **previous values**.

https://lit.dev/docs/components/lifecycle/#reactive-update-cycle