### PR TITLE
fix: init additionalProperties with an empty object to allow them

### DIFF
--- a/src/organisms/gv-schema-form.js
+++ b/src/organisms/gv-schema-form.js
@@ -461,7 +461,7 @@ export class GvSchemaForm extends LitElement {
   validate() {
     if (this.schema) {
       // Additional properties should not block the validation of the form
-      this._validatorResults = this._validator.validate(this._values, { ...this.schema, additionalProperties: true });
+      this._validatorResults = this._validator.validate(this._values, { ...this.schema, additionalProperties: {} });
       this.errors = this._getErrors();
     }
     return this._validatorResults;


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/6781

**Description**
to allow additionalProperties we need to init empty object and not define it to true
See code [here](https://github.com/tdegrunt/jsonschema/blob/6f6512981327c20802852fa32fa3dd4f315f7ce1/lib/attribute.js#L303)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

