### PR TITLE
fix(gv-http-client): fix Lit import for repeat directive

### DIFF
--- a/src/organisms/gv-http-client/gv-http-client.js
+++ b/src/organisms/gv-http-client/gv-http-client.js
@@ -29,7 +29,7 @@ import { empty } from '../../styles/empty';
 import { httpClientSchemaForm } from '../../lib/http-client-schema-form';
 import { dispatchCustomEvent } from '../../lib/events';
 import { statusCode } from '../../lib/http';
-import { repeat } from 'lit-html/directives/repeat';
+import { repeat } from 'lit/directives/repeat';
 
 /**
  * @fires gv-http-client:send - Event sent when


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-ui-components/issues/539

**Description**

Change `repeat` import from `lit-html` to `lit`

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-gbwvuryxsp.chromatic.com)
<!-- Storybook placeholder end -->

**🔥  Result**
![image](https://user-images.githubusercontent.com/47851994/148504074-1e498e28-ef9b-476d-8479-ced00b0edeb9.png)

