### PR TITLE
Override href from asciidoctor ToC

### DIFF
--- a/src/lib/text-format.js
+++ b/src/lib/text-format.js
@@ -38,12 +38,17 @@ export function toDom(text, type = 'adoc', small = false) {
     if (text) {
       let innerHTML = '';
       if (type === 'adoc') {
-        innerHTML = asciidoctor.convert(text, {
-          attributes: {
-            showtitle: true,
-            'source-highlighter': 'highlightjs-ext',
-          },
-        });
+        innerHTML = asciidoctor
+          .convert(text, {
+            attributes: {
+              showtitle: true,
+              'source-highlighter': 'highlightjs-ext',
+            },
+          })
+          // Replace href links to include potential parts of the URL that can be set by Angular router or
+          // any other routing framework. By default, href will have the following format:
+          // href="[SERVER_BASE]/#a_link" i.e. href="https://apim-master-portal.cloud.gravitee.io/#a_link"
+          .replace(/href="#/g, `href="${window.location.href}#`);
       } else {
         throw new Error(`Library not found for type : '${type}' | ${text}`);
       }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6952

**Description**

Replace href links to include potential parts of the URL that can be set by Angular router or any other routing framework. By default, href will have the following format: href="[SERVER_BASE]/#a_link" i.e. href="https://apim-master-portal.cloud.gravitee.io/#a_link"
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-auiidkcfai.chromatic.com)
<!-- Storybook placeholder end -->
