### PR TITLE
Revert "ci: remove manual approval to run chromatic job"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,15 @@ workflows:
           context: gravitee-qa
           requires:
             - build
+      - trigger-chromatic:
+          type: approval
+          requires:
+            - build
+            - lint-test
+          # Ignore this manual step and trigger chromatic automatically on `master`
+          filters:
+            branches:
+              ignore: master
       - chromatic-deployment:
           pre-steps:
             - secrethub/env-export:
@@ -238,6 +247,7 @@ workflows:
           context: gravitee-qa
           requires:
             - build
+            - trigger-chromatic
       - release:
           pre-steps:
             - secrethub/env-export:


### PR DESCRIPTION
**Issue**

NA

**Description**

😱  We are running out of credits for Chromatic so I added back the manual validation before Chromatic job in PR workflow.

![image](https://user-images.githubusercontent.com/4112568/152828357-fccd74c4-624c-4acb-ac08-1b359a3dc088.png)


This reverts commit bfe5faa3f2bc6d925dbe41e54898cf3e7758bad2.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-kamngrwrfw.chromatic.com)
<!-- Storybook placeholder end -->
