### PR TITLE
fix(gv-policy-studio): auto submit dirty form if is necessary

### DIFF
--- a/src/policy-studio/gv-policy-studio/gv-policy-studio.js
+++ b/src/policy-studio/gv-policy-studio/gv-policy-studio.js
@@ -1387,14 +1387,12 @@ export class GvPolicyStudio extends KeyboardElement(LitElement) {
     return [...this.shadowRoot.querySelectorAll('gv-schema-form')]
       .filter((form) => {
         const isValid = form.isValid();
-        if (isValid) {
+        if (isValid && form.dirty) {
           form.submit();
-        } else {
-          form.dirty = true;
         }
         return !isValid;
       })
-      .map((form) => form.confirm());
+      .map((form) => form.confirm(true));
   }
 
   getPropertiesElement() {


### PR DESCRIPTION
**Issue**

We introduced a regression with rework for debug mode. 
We cannot add a policy to a flow.
It's reproductible with Policy Studio / Empty story, just try to drag and drop a policy.

gravitee-io/issues#7159

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-cryvntinxg.chromatic.com)
<!-- Storybook placeholder end -->
