### PR TITLE
feat: add icons for new AM flows

### DIFF
--- a/src/lib/studio.js
+++ b/src/lib/studio.js
@@ -84,6 +84,7 @@ export function getFlowTitle(flow, collectionName, withMethods = true, draggable
     if (flow.condition) {
       rendering.push(html` <gv-icon title="Conditional flow" className="content-icon-conditional" shape="design:conditional"></gv-icon>`);
     }
+    // TODO: Extract icon/shape on flow definition
     const methods = flow.methods || [];
     if (flow.type != null) {
       let shape = null;
@@ -91,6 +92,10 @@ export function getFlowTitle(flow, collectionName, withMethods = true, draggable
         shape = 'home:earth';
       } else if (flow.type.toUpperCase() === 'LOGIN') {
         shape = 'general:shield-protected';
+      } else if (flow.type.toUpperCase() === 'LOGIN_IDENTIFIER') {
+        shape = 'navigation:sign-in';
+      } else if (flow.type.toUpperCase() === 'RESET_PASSWORD') {
+        shape = 'action:lock_open';
       } else if (flow.type.toUpperCase() === 'CONSENT') {
         shape = 'general:shield-check';
       } else if (flow.type.toUpperCase() === 'REGISTER') {

--- a/src/policy-studio/gv-policy-studio/gv-policy-studio.test.js
+++ b/src/policy-studio/gv-policy-studio/gv-policy-studio.test.js
@@ -256,7 +256,7 @@ describe('P O L I C Y  S T U D I O', () => {
             description: 'The type of flow',
             type: 'string',
             default: 'ROOT',
-            enum: ['ROOT', 'LOGIN', 'CONSENT', 'REGISTER'],
+            enum: ['ROOT', 'LOGIN', 'LOGIN_IDENTIFIER', 'RESET_PASSWORD', 'CONSENT', 'REGISTER'],
           },
           condition: {
             title: 'Condition',

--- a/testing/resources/am-definition.json
+++ b/testing/resources/am-definition.json
@@ -9,6 +9,20 @@
       "post": []
     },
     {
+      "name": "LOGIN IDENTIFIER",
+      "type": "LOGIN_IDENTIFIER",
+      "condition": "",
+      "pre": [],
+      "post": []
+    },
+    {
+      "name": "RESET PASSWORD",
+      "type": "RESET_PASSWORD",
+      "condition": "",
+      "pre": [],
+      "post": []
+    },
+    {
       "name": "LOGIN",
       "type": "LOGIN",
       "condition": "",

--- a/testing/resources/schemas/am.json
+++ b/testing/resources/schemas/am.json
@@ -13,7 +13,7 @@
       "description": "The type of flow",
       "type": "string",
       "default": "ROOT",
-      "enum": ["ROOT", "LOGIN", "CONSENT", "REGISTER"]
+      "enum": ["ROOT", "LOGIN_IDENTIFIER", "RESET_PASSWORD", "LOGIN", "CONSENT", "REGISTER"]
     },
     "condition": {
       "title": "Condition",


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7193

**Description**

This PR handles new icons for new AM flows.

**Additional context**

as discussed with @gaetanmaisse and @ThibaudAV some work will be done to handle `shape` in the flow schemas
in the future.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-lglghnfmps.chromatic.com)
<!-- Storybook placeholder end -->
