### PR TITLE
fix: not click twice to validate policy schema-form

### DIFF
--- a/src/policy-studio/gv-design/gv-design.js
+++ b/src/policy-studio/gv-design/gv-design.js
@@ -987,7 +987,6 @@ export class GvDesign extends KeyboardElement(LitElement) {
                 has-header
                 validate-on-render
                 .values="${values}"
-                .dirty="${this._currentFlowStep._values != null}"
                 ?readonly="${readonlyMode}"
                 scrollable
                 .groups="${groups}"

--- a/src/policy-studio/gv-policy-studio/gv-policy-studio.js
+++ b/src/policy-studio/gv-policy-studio/gv-policy-studio.js
@@ -1113,7 +1113,6 @@ export class GvPolicyStudio extends KeyboardElement(LitElement) {
                 has-header
                 validate-on-render
                 .values="${values}"
-                .dirty="${this._currentFlowStep._values != null}"
                 ?readonly="${readonlyMode}"
                 scrollable
                 .groups="${groups}"


### PR DESCRIPTION
**Issue**
na

**Description**
fix this : 

in the debug (without menu) when add a policy then add a description and then we have to validate twice 
in the policy studio (with menu) in all cases when we modify the policy description we have to validate twice


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-qneeeswngk.chromatic.com)
<!-- Storybook placeholder end -->
