### PR TITLE
perf: add webpack config to limit languages imported by the dependencies

### DIFF
--- a/src/atoms/gv-date-picker/gv-date-picker.js
+++ b/src/atoms/gv-date-picker/gv-date-picker.js
@@ -295,7 +295,13 @@ export class GvDatePicker extends LitElement {
     }
     if (!locales[lang]) {
       try {
-        const locale = await import(`date-fns/locale/${lang}/index.js`);
+        const locale = await import(
+          // TODO: complete or improve the solution when managing a larger set of languages
+          /* webpackInclude: /(en|fr|cs)\/index\.js$/ */
+          /* webpackMode: "lazy-once" */
+          /* webpackChunkName: "date-fns-locale" */
+          `date-fns/locale/${lang}/index.js`
+        );
         locales[lang] = locale.default;
       } catch (e) {
         console.error(`[Error] cannot load locale ${lang}`, e);

--- a/src/atoms/gv-input/gv-input.js
+++ b/src/atoms/gv-input/gv-input.js
@@ -273,8 +273,8 @@ export class GvInput extends InputElement(LitElement) {
     }
   }
 
-  firstUpdated(changedProperties) {
-    super.firstUpdated(changedProperties);
+  firstUpdated() {
+    super.firstUpdated();
 
     this.catchSlot();
 

--- a/src/atoms/gv-relative-time/gv-relative-time.js
+++ b/src/atoms/gv-relative-time/gv-relative-time.js
@@ -74,7 +74,13 @@ export class GvRelativeTime extends LitElement {
           .then(() =>
             Promise.all([
               ...Object.values(getAvailableLanguages()).map((_lang) => {
-                return import(`@formatjs/intl-relativetimeformat/locale-data/${_lang}`);
+                return import(
+                  // TODO: complete or improve the solution when managing a larger set of languages
+                  /* webpackInclude: /(en|fr|cs)\.js$/ */
+                  /* webpackMode: "lazy-once" */
+                  /* webpackChunkName: "intl-relativetimeformat-locale-data" */
+                  `@formatjs/intl-relativetimeformat/locale-data/${_lang}`
+                );
               }),
             ]),
           )

--- a/src/atoms/gv-select-native/gv-select-native.js
+++ b/src/atoms/gv-select-native/gv-select-native.js
@@ -183,8 +183,8 @@ export class GvSelectNative extends InputElement(LitElement) {
     return this.shadowRoot.querySelector('select');
   }
 
-  async firstUpdated(changedProperties) {
-    super.firstUpdated(changedProperties);
+  async firstUpdated() {
+    super.firstUpdated();
     // Give the browser a chance to paint
     await new Promise((resolve) => setTimeout(resolve, 0));
     const input = this.getInputElement();

--- a/src/molecules/gv-confirm/gv-confirm.js
+++ b/src/molecules/gv-confirm/gv-confirm.js
@@ -156,8 +156,8 @@ export class GvConfirm extends GvPopover {
     `;
   }
 
-  firstUpdated(changedProperties) {
-    super.firstUpdated(changedProperties);
+  firstUpdated() {
+    super.firstUpdated();
     if (this.danger) {
       this.shadowRoot.querySelectorAll('gv-button').forEach((btn) => btn.setAttribute('danger', ''));
     }

--- a/src/molecules/gv-popover/gv-popover.js
+++ b/src/molecules/gv-popover/gv-popover.js
@@ -260,7 +260,7 @@ export class GvPopover extends LitElement {
     return html`<slot name="popover"></slot>`;
   }
 
-  firstUpdated(_changedProperties) {
+  firstUpdated() {
     setTimeout(() => {
       this.addEventListener(this.event, this._open.bind(this));
       if (this.event.startsWith('mouse') && this.delay === 0) {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6666

**Description**
add webpack config to limit languages imported by the dependencies

**Additional context**


I looked for other solutions. But they are all more complex
And I think that ui-component should not support all languages but only a set of languages chosen by the product
And that all this work should be done for a specific multilingual topic 
