### PR TITLE
fix(gv-icon): use svg lit directive

### DIFF
--- a/src/atoms/gv-icon/gv-icon.js
+++ b/src/atoms/gv-icon/gv-icon.js
@@ -13,19 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { css, LitElement, html, noChange } from 'lit';
-import { Directive, directive } from 'lit/directive.js';
+import { css, LitElement, html, svg } from 'lit';
 
 import { classMap } from 'lit/directives/class-map.js';
-
-class Namespaced extends Directive {
-  update(part, [namespace, value]) {
-    part.element.setAttributeNS(namespace, part.name, value);
-    return noChange;
-  }
-}
-
-const namespaced = directive(Namespaced);
 
 /**
  * An icon
@@ -93,10 +83,8 @@ export class GvIcon extends LitElement {
   }
 
   render() {
-    const xlinkNamespace = 'http://www.w3.org/1999/xlink';
-    return html`<svg class="${classMap({ 'no-color': !this.canCustomize() })}">
-      <use xlink:href="${namespaced(xlinkNamespace, GvIcon.getHref(this.shape))}" />
-    </svg>`;
+    const icon = svg`<use href="${GvIcon.getHref(this.shape)}" />`;
+    return html`<svg xmlns="http://www.w3.org/2000/svg" class="${classMap({ 'no-color': !this.canCustomize() })}">${icon}</svg>`;
   }
 }
 


### PR DESCRIPTION
```ts
/**
 * Interprets a template literal as an SVG fragment that can efficiently
 * render to and update a container.
 *
 * ```ts
 * const rect = svg`<rect width="10" height="10"></rect>`;
 *
 * const myImage = html`
 *   <svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
 *     ${rect}
 *   </svg>`;
 * ```
 *
 * The `svg` *tag function* should only be used for SVG fragments, or elements
 * that would be contained **inside** an `<svg>` HTML element. A common error is
 * placing an `<svg>` *element* in a template tagged with the `svg` tag
 * function. The `<svg>` element is an HTML element and should be used within a
 * template tagged with the {@linkcode html} tag function.
 *
 * In LitElement usage, it's invalid to return an SVG fragment from the
 * `render()` method, as the SVG fragment will be contained within the element's
 * shadow root and thus cannot be used within an `<svg>` HTML element.
 */
export declare const svg: (strings: TemplateStringsArray, ...values: unknown[]) => TemplateResult<2>;
```

Also `link:href` attribute is deprecated https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-lthwtaefdz.chromatic.com)
<!-- Storybook placeholder end -->
