### PR TITLE
feat: hide closed plans in design studio

### DIFF
--- a/src/policy-studio/gv-design/gv-design.js
+++ b/src/policy-studio/gv-design/gv-design.js
@@ -324,9 +324,11 @@ export class GvDesign extends KeyboardElement(LitElement) {
       const plans =
         definition.plans == null
           ? []
-          : definition.plans.map((plan) => {
-              return { ...plan, flows: this._generatePlanFlowsId(plan) };
-            });
+          : definition.plans
+              .filter((plan) => plan.status !== 'CLOSED')
+              .map((plan) => {
+                return { ...plan, flows: this._generatePlanFlowsId(plan) };
+              });
       this._initialDefinition = { ...definition, flows, resources, plans };
       this._definition = deepClone(this._initialDefinition);
       this.isDirty = false;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7693

**Description**

feat: hide closed plans in design studio

Now, when retrieving an api using the endpoint /api/{id},
It returns all plans, including closed ones.
So, we have to hide them in design studio.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-ewlnectgjf.chromatic.com)
<!-- Storybook placeholder end -->
