### PR TITLE
feat: add new gv-shema-form-group

### DIFF
--- a/src/organisms/gv-schema-form-group/gv-schema-form-group.stories.js
+++ b/src/organisms/gv-schema-form-group/gv-schema-form-group.stories.js
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import './gv-schema-form-group';
+import { makeStory } from '../../../testing/lib/make-story';
+import mixed from '../../../testing/resources/schemas/mixed.json';
+import htmlToJson from '../../../testing/resources/schemas/html-to-json.json';
+import httpConnector from '../../../testing/resources/schemas/http-connector.json';
+import { fetch } from 'whatwg-fetch';
+import grammar from '../../../testing/resources/el-grammar.json';
+import resourceCacheRedis from '../../../testing/resources/schemas/resource-cache-redis.json';
+
+export default {
+  title: 'Organisms/gv-schema-form-group',
+  component: 'gv-schema-form-group',
+  parameters: {
+    // DO NOT REACTIVATE a11y on these stories for now as the a11y checks are taking forever to run
+    a11y: { disable: true },
+  },
+};
+
+const conf = {
+  component: 'gv-schema-form-group',
+  // language=CSS
+  css: `
+    :host {
+      display: block;
+      min-height: 700px;
+    }
+
+    gv-schema-form-group {
+      display: block;
+      position: relative;
+      min-height: 700px;
+    }
+  `,
+};
+
+export const MixedEmpty = makeStory(conf, {
+  items: [
+    {
+      title: 'Mixed Empty',
+      schema: mixed,
+      '@gv-schema-form-group:fetch-data': (event) => {
+        const options = 'abcdefghijklmnopqrstuvwxyz0123456789'.split('').map((key, index) => ({ value: `This is generated with ${key}` }));
+        event.detail.currentTarget.options = options;
+      },
+      'has-footer': true,
+      scrollable: true,
+      '@gv-expression-language:ready': ({ detail }) => {
+        detail.currentTarget.grammar = grammar;
+      },
+      'validate-on-render': true,
+    },
+  ],
+});
+
+const mixedValues = {
+  body: '<xml></xml>',
+  'path-operator': {
+    path: '/public',
+    operator: 'EQUALS',
+  },
+  resources: 'My resource',
+  attributes: [
+    { name: 'John', value: 'Doe' },
+    { name: 'Foo', value: 'Bar' },
+  ],
+  useResponseCacheHeaders: true,
+  timeToLiveSeconds: 50,
+  select: 'b',
+  multiselect: ['a', 'b', 'c'],
+};
+
+export const Skeleton = makeStory(conf, {
+  items: [
+    {
+      title: 'mixed',
+      skeleton: true,
+      icon: 'design:edit',
+      value: mixedValues,
+      schema: mixed,
+      '@gv-schema-form-group:fetch-data': (event) => {
+        const options = 'abcdefghijklmnopqrstuvwxyz0123456789'.split('').map((key, index) => ({ value: `This is generated with ${key}` }));
+        event.detail.currentTarget.options = options;
+      },
+      '@gv-expression-language:ready': ({ detail }) => {
+        detail.currentTarget.grammar = grammar;
+      },
+    },
+  ],
+});
+
+export const Mixed = makeStory(conf, {
+  items: [
+    {
+      title: 'mixed',
+      icon: 'design:edit',
+      value: mixedValues,
+      schema: mixed,
+      '@gv-schema-form-group:fetch-data': (event) => {
+        const options = 'abcdefghijklmnopqrstuvwxyz0123456789'.split('').map((key, index) => ({ value: `This is generated with ${key}` }));
+        event.detail.currentTarget.options = options;
+      },
+      '@gv-expression-language:ready': ({ detail }) => {
+        detail.currentTarget.grammar = grammar;
+      },
+      '@gv-schema-form-group:change': ({ detail }) => {
+        detail.target.values = detail.values;
+      },
+      'validate-on-render': true,
+    },
+  ],
+});
+
+export const HTMLToJson = makeStory(conf, {
+  items: [{ schema: htmlToJson, 'has-footer': true }],
+});
+
+export const HttpConnector = makeStory(conf, {
+  items: [{ schema: httpConnector }],
+});
+
+export const ResourceCacheRedis = makeStory(conf, {
+  items: [{ schema: resourceCacheRedis, 'has-footer': true }],
+});
+
+let policies = [
+  'gravitee-policy-ratelimit/gravitee-policy-quota',
+  'gravitee-policy-ratelimit/gravitee-policy-ratelimit',
+  'gravitee-policy-ratelimit/gravitee-policy-spikearrest',
+  'gravitee-policy-apikey',
+  'gravitee-policy-request-content-limit',
+  'gravitee-policy-oauth2',
+  'gravitee-policy-transformheaders',
+  'gravitee-policy-rest-to-soap',
+  'gravitee-policy-transformqueryparams',
+  'gravitee-policy-ipfiltering',
+  'gravitee-policy-mock',
+  'gravitee-policy-cache',
+  'gravitee-policy-xslt',
+  'gravitee-policy-xml-json',
+  'gravitee-policy-groovy',
+  'gravitee-policy-dynamic-routing',
+  'gravitee-policy-jwt',
+  'gravitee-policy-resource-filtering',
+  'gravitee-policy-json-to-json',
+  'gravitee-policy-blank',
+  'gravitee-policy-latency',
+  'gravitee-policy-basic-authentication',
+  'gravitee-policy-override-http-method',
+  'gravitee-policy-request-validation',
+  'gravitee-policy-openid-connect-userinfo',
+  'gravitee-policy-assign-content',
+  'gravitee-policy-jws',
+  'gravitee-policy-json-validation',
+  'gravitee-policy-url-rewriting',
+  'gravitee-policy-xml-validation',
+  'gravitee-policy-callout-http',
+  'gravitee-policy-assign-attributes',
+  'gravitee-policy-generate-jwt',
+  'gravitee-policy-role-based-access-control',
+  'gravitee-policy-ssl-enforcement',
+  'gravitee-policy-geoip-filtering',
+  'gravitee-policy-circuit-breaker',
+  'gravitee-policy-regex-threat-protection',
+  'gravitee-policy-xml-threat-protection',
+  'gravitee-policy-json-threat-protection',
+  'gravitee-policy-wssecurity-authentication',
+  'gravitee-policy-aws-lambda',
+  'gravitee-policy-retry',
+].map((value) => ({ value, view: 0, error: 0 }));
+// Github rate limit: 60 request per hour
+// Useful to generate the table of policies
+// eslint-disable-next-line no-unused-vars
+async function fetchAllPolicies() {
+  const fakeOrEmptyPolicies = [
+    // Technical repo
+    'gravitee-policy-maven-archetype',
+    'gravitee-policy-authentication',
+    'gravitee-policy-api',
+    // Multi policies repo
+    'gravitee-policy-ratelimit',
+    // Generate policies repo
+    'gravitee-policy-html-json',
+    'gravitee-policy-keyless',
+  ];
+  const githubUrl = 'https://api.github.com/orgs/gravitee-io/repos?per_page=100&page=';
+
+  return Promise.all([fetch(`${githubUrl}1`), fetch(`${githubUrl}2`)])
+    .then(([a, b]) => {
+      return Promise.all([a.json(), b.json()]);
+    })
+    .then(([firstPage, secondPage]) => {
+      const repositories = [...firstPage, ...secondPage];
+      policies = [
+        'gravitee-policy-ratelimit/gravitee-policy-quota',
+        'gravitee-policy-ratelimit/gravitee-policy-ratelimit',
+        'gravitee-policy-ratelimit/gravitee-policy-spikearrest',
+        ...repositories
+          .filter((repo) => repo.archived === false && repo.name.startsWith('gravitee-policy-') && !fakeOrEmptyPolicies.includes(repo.name))
+          .map(({ name }) => name),
+      ];
+
+      // eslint-disable-next-line no-console
+      console.log(policies);
+    });
+}

--- a/src/organisms/gv-schema-form-group/gv-schema-form-group.test.js
+++ b/src/organisms/gv-schema-form-group/gv-schema-form-group.test.js
@@ -1,0 +1,516 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { Page, querySelector, since } from '../../../testing/lib/test-utils';
+import './gv-schema-form-group';
+import mixed from '../../../testing/resources/schemas/mixed.json';
+import fieldsDependencies from '../../../testing/resources/schemas/fields-dependencies.json';
+import fieldsConditional from '../../../testing/resources/schemas/fields-conditional.json';
+import httpConnector from '../../../testing/resources/schemas/http-connector.json';
+import { deepClone } from '../../lib/utils';
+
+describe('S C H E M A  F O R M  G R O U P', () => {
+  let page;
+  let component;
+
+  beforeEach(async () => {
+    page = new Page();
+    component = page.create('gv-schema-form-group', {
+      schema: mixed,
+    });
+    await component.updateComplete;
+  });
+
+  afterEach(() => {
+    page.clear();
+  });
+
+  const mixedControls = [
+    'body',
+    'el',
+    'body-with-el',
+    'path-operator',
+    'resources',
+    'another-list-resources',
+    'attributes',
+    'timeToLiveSeconds',
+    'useResponseCacheHeaders',
+    'select',
+    'multiselect',
+    'cron',
+    'disabled',
+    'hidden-with-condition',
+    'hidden',
+    'readonly',
+    'writeonly',
+    'whitelist',
+  ];
+
+  const checkControl = (id, attributes = []) => {
+    const ids = id.split('.');
+    const acc = [];
+    let element = component.getControl(ids[0]);
+    if (ids.length > 1) {
+      ids.forEach((_id) => {
+        acc.push(_id);
+        element = element.getControl(acc.join('.'));
+      });
+    }
+
+    since(`Element [id="${id}"] not found`, () => expect(element).not.toBeNull());
+
+    const expectedAttributes = Array.isArray(attributes) ? attributes : Object.keys(attributes);
+
+    expectedAttributes.forEach((attr) => {
+      since(`Element [id="${id}"] not have attr [${attr}]`, () => expect(element[attr]).toBeTruthy());
+      if (attributes[attr] != null) {
+        expect(element[attr]).toEqual(attributes[attr]);
+      }
+    });
+  };
+
+  test('should create element', async () => {
+    expect(window.customElements.get('gv-schema-form-group')).toBeDefined();
+    expect(component).toEqual(querySelector('gv-schema-form-group'));
+
+    await component.updateComplete;
+
+    expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+
+    checkControl('body');
+    checkControl('el');
+    checkControl('body-with-el');
+    checkControl('path-operator');
+    checkControl('resources');
+    checkControl('timeToLiveSeconds');
+    checkControl('useResponseCacheHeaders');
+    checkControl('select');
+    checkControl('multiselect');
+    checkControl('whitelist');
+  });
+
+  test('should create element with valid value', async () => {
+    component.value = {
+      body: '<xml>foobar</xml>',
+      el: `{#request.headers['Content-Type'][0].toString()}`,
+      'body-with-el': `<xml name="{#request.headers['Content-Type'][0].toString()}"></xml>`,
+      'path-operator': {
+        operator: 'EQUALS',
+        path: '/foobar',
+      },
+      resources: 'my-resource',
+      timeToLiveSeconds: 50,
+      useResponseCacheHeaders: true,
+      select: 'b',
+      multiselect: ['a', 'b', 'c'],
+      attributes: [{ name: 'foo', value: 'bar' }],
+      cron: '*/30 * * * * SUN-MON',
+      disabled: 'Simple Test',
+      hidden: 'not visible',
+    };
+
+    component.requestUpdate();
+    await component.updateComplete;
+
+    expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+
+    checkControl('body', { value: '<xml>foobar</xml>' });
+    checkControl('path-operator', { value: { operator: 'EQUALS', path: '/foobar' } });
+    checkControl('path-operator.path', { value: '/foobar' });
+    checkControl('path-operator.operator', { value: 'EQUALS' });
+    checkControl('resources', { value: 'my-resource' });
+    checkControl('timeToLiveSeconds', { value: 50 });
+    checkControl('useResponseCacheHeaders', {});
+    checkControl('select', { value: 'b' });
+    checkControl('multiselect', { value: ['a', 'b', 'c'] });
+    checkControl('attributes', { value: [{ name: 'foo', value: 'bar' }] });
+    checkControl('attributes.0', { value: { name: 'foo', value: 'bar' } });
+    checkControl('cron', { value: '*/30 * * * * SUN-MON' });
+    checkControl('disabled', { value: 'Simple Test' });
+    checkControl('hidden', { value: 'not visible', hidden: true });
+    checkControl('whitelist', {});
+  });
+
+  test('should disable element if "select" is "a"', async () => {
+    component.value = {
+      select: 'a',
+      disabled: 'Simple Test',
+    };
+    component.requestUpdate();
+
+    await component.updateComplete;
+
+    expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+
+    checkControl('disabled', { value: 'Simple Test' });
+
+    expect(component.getControl('disabled').disabled).toBeTruthy();
+  });
+
+  test('should not disable element if "select" is not "a"', async () => {
+    component.value = {
+      select: 'b',
+      disabled: 'Simple Test',
+    };
+    component.requestUpdate();
+
+    await component.updateComplete;
+
+    expect(component.getControls().map((e) => e.id)).toEqual(mixedControls);
+
+    checkControl('disabled', { value: 'Simple Test' });
+
+    expect(component.getControl('disabled').disabled).toBeFalsy();
+  });
+
+  test('should create element with invalid value', async () => {
+    component.value = {
+      body: '<xml></xml>',
+      'path-operator': {
+        operator: 'Fake value',
+        path: 'not a path',
+      },
+      resources: 'my-resource',
+      timeToLiveSeconds: 'not number',
+      useResponseCacheHeaders: true,
+      select: 'b',
+      multiselect: ['a', 'b', 'c'],
+      attributes: [{ name: 'foo', value: '' }, {}],
+    };
+
+    await component.updateComplete;
+
+    checkControl('body', { value: '<xml></xml>' });
+    checkControl('path-operator', { value: { operator: 'Fake value', path: 'not a path' } });
+    checkControl('path-operator.path', { value: 'not a path' });
+    checkControl('path-operator.operator', { value: 'Fake value' });
+    checkControl('resources', { value: 'my-resource' });
+    checkControl('timeToLiveSeconds', { value: 'not number' });
+    checkControl('useResponseCacheHeaders', {});
+    checkControl('select', { value: 'b' });
+    checkControl('multiselect', { value: ['a', 'b', 'c'] });
+    checkControl('attributes', { value: [{ name: 'foo', value: '' }, {}] });
+    checkControl('attributes.0', { value: { name: 'foo', value: '' } });
+    checkControl('attributes.1', { value: {} });
+  });
+
+  test('should update value & dirty state when user change the form', () => {
+    component.value = {
+      timeToLiveSeconds: 5,
+      body: '<xml></xml>',
+    };
+    expect(component.dirty).toBeUndefined();
+    const detail = { control: { type: 'integer' }, value: '16', currentTarget: { id: 'timeToLiveSeconds' } };
+    component._onChange({ detail });
+
+    expect(component.dirty).toEqual(true);
+    expect(component.value.timeToLiveSeconds).toEqual(16);
+  });
+
+  test('should catch custom event after create control', (done) => {
+    component = page.create('gv-schema-form-group', {
+      schema: mixed,
+    });
+
+    let nbOfEmittedEvents = 0;
+    component.addEventListener('gv-schema-form-group:fetch-data', ({ detail }) => {
+      nbOfEmittedEvents++;
+      expect(detail.name).toEqual('fetch-data');
+      expect(detail.currentTarget.tagName.toLowerCase()).toEqual('gv-autocomplete');
+      if (nbOfEmittedEvents === 2) {
+        done();
+      }
+    });
+  });
+
+  test('should reset initial value', (done) => {
+    const preventDefault = jest.fn();
+    const stopPropagation = jest.fn();
+    const value = {
+      'path-operator': {
+        operator: 'STARTS_WITH',
+        path: '/my-path',
+      },
+      timeToLiveSeconds: 5,
+      multiselect: ['a'],
+    };
+    component.value = deepClone(value);
+    component.updateComplete.then(() => {
+      const pathOperatorControl = component.getControl('path-operator');
+
+      expect(pathOperatorControl).not.toBeNull();
+      pathOperatorControl._onInput({
+        preventDefault,
+        stopPropagation,
+        target: { id: 'path-operator.path' },
+        detail: '/updated-path',
+      });
+
+      const timeToLiveSeconds = component.getControl('timeToLiveSeconds');
+      expect(timeToLiveSeconds).not.toBeNull();
+      timeToLiveSeconds._onInput({
+        preventDefault,
+        stopPropagation,
+        target: { id: 'timeToLiveSeconds' },
+        detail: 12,
+      });
+
+      const multiselect = component.getControl('multiselect');
+      multiselect._onInput({
+        preventDefault,
+        stopPropagation,
+        target: { id: 'multiselect' },
+        detail: ['a', 'b'],
+      });
+
+      expect(component.value).toEqual({
+        'path-operator': {
+          operator: 'STARTS_WITH',
+          path: '/updated-path',
+        },
+        readonly: 'Should not edit my value',
+        timeToLiveSeconds: 12,
+        writeonly: 'Should not read my value',
+        multiselect: ['a', 'b'],
+      });
+
+      component.reset();
+
+      expect(component.value).toEqual(value);
+      done();
+    });
+  });
+
+  test('should remove value with empty string & empty array', (done) => {
+    const preventDefault = jest.fn();
+    const stopPropagation = jest.fn();
+    const value = {
+      'path-operator': {
+        operator: 'STARTS_WITH',
+        path: '/my-path',
+      },
+      timeToLiveSeconds: 5,
+      multiselect: ['a'],
+      whitelist: [
+        {
+          pattern: 'abc',
+          methods: [],
+        },
+      ],
+    };
+    component.value = deepClone(value);
+
+    component.updateComplete.then(() => {
+      const pathOperatorControl = component.getControl('path-operator');
+      expect(pathOperatorControl).not.toBeNull();
+      pathOperatorControl._onInput({
+        preventDefault,
+        stopPropagation,
+        target: { id: 'path-operator.path' },
+        detail: '',
+      });
+
+      const timeToLiveSeconds = component.getControl('timeToLiveSeconds');
+      expect(timeToLiveSeconds).not.toBeNull();
+      timeToLiveSeconds._onInput({
+        preventDefault,
+        stopPropagation,
+        target: { id: 'timeToLiveSeconds' },
+        detail: '',
+      });
+
+      const multiselect = component.getControl('multiselect');
+      multiselect._onInput({
+        preventDefault,
+        stopPropagation,
+        target: { id: 'multiselect' },
+        detail: [],
+      });
+
+      const whitelist = component.getControl('whitelist');
+      whitelist._onInput({
+        preventDefault,
+        stopPropagation,
+        target: { id: 'whitelist' },
+        detail: [],
+      });
+
+      expect(component.value).toEqual({
+        'path-operator': {
+          operator: 'STARTS_WITH',
+        },
+        readonly: 'Should not edit my value',
+        writeonly: 'Should not read my value',
+        multiselect: [],
+      });
+
+      done();
+    });
+  });
+
+  test('should validate schema with dependencies form', () => {
+    component.schema = fieldsDependencies;
+
+    component.value = {
+      'path-operator': {
+        operator: 'EQUALS',
+        path: '/foobar',
+      },
+    };
+
+    component.validate();
+    expect(component.errors).toEqual([]);
+
+    component.value = {
+      'path-operator': {
+        operator: 'EQUALS',
+        path: '/foobar',
+      },
+      select: 'a',
+    };
+
+    component.validate();
+    expect(component.errors).toEqual([
+      {
+        path: [],
+        property: 'instance',
+        message: 'property timeToLiveSeconds not found, required by instance.select',
+        schema: 'story',
+        instance: {
+          'path-operator': {
+            operator: 'EQUALS',
+            path: '/foobar',
+          },
+          select: 'a',
+        },
+        name: 'dependencies',
+        argument: 'instance.select',
+        stack: 'instance property timeToLiveSeconds not found, required by instance.select',
+      },
+    ]);
+  });
+
+  test('should validate schema with oneOf', () => {
+    component.schema = fieldsDependencies;
+
+    component.value = {
+      select: 'a',
+      'path-operator': {
+        operator: 'EQUALS',
+        path: '/foobar',
+      },
+      timeToLiveSeconds: 2,
+    };
+
+    component.validate();
+    expect(component.errors).toEqual([
+      {
+        path: ['timeToLiveSeconds'],
+        property: 'instance.timeToLiveSeconds',
+        message: 'is not exactly one from [subschema 0],[subschema 1]',
+        schema: {
+          title: 'Time to live (in seconds)',
+          default: 600,
+          description: 'Required only if select has value',
+          type: 'integer',
+          minimum: 0,
+          maximum: 1000,
+          oneOf: [
+            {
+              type: 'number',
+              multipleOf: 5,
+            },
+            {
+              type: 'number',
+              multipleOf: 3,
+            },
+          ],
+        },
+        instance: 2,
+        name: 'oneOf',
+        argument: ['[subschema 0]', '[subschema 1]'],
+        stack: 'instance.timeToLiveSeconds is not exactly one from [subschema 0],[subschema 1]',
+      },
+    ]);
+  });
+
+  test('should validate schema with conditions and custom error message', () => {
+    component.schema = fieldsConditional;
+
+    component.value = {};
+
+    component.validate();
+    expect(component.errors).toEqual([]);
+
+    component.value = {
+      type: 'b',
+      path: 'file://',
+      content: 'binary',
+    };
+
+    component.validate();
+    expect(component.errors).toEqual([]);
+
+    component.value = {
+      type: 'c',
+      path: 'file://',
+      content: 'binary',
+    };
+
+    component.validate();
+    expect(component.errors).toEqual([]);
+  });
+
+  test('should validate complex schema', () => {
+    component.schema = httpConnector;
+
+    component.value = {};
+    component.validate();
+    expect(component.errors).toEqual([]);
+
+    component.value = {
+      ssl: {
+        trustStore: {
+          type: 'PEM',
+        },
+      },
+    };
+    component.validate();
+    expect(component.errors[0].message).toEqual(
+      'A path or a content is <span class="error">required</span> - for JKS and PKCS#12 a password is also <span class="error">required</span>',
+    );
+  });
+
+  test('should validate with additional properties', () => {
+    component.value = {
+      body: '<xml>foobar</xml>',
+      'path-operator': {
+        operator: 'EQUALS',
+        path: '/foobar',
+      },
+      resources: 'my-resource',
+      timeToLiveSeconds: 50,
+      useResponseCacheHeaders: true,
+      select: 'b',
+      multiselect: ['a', 'b', 'c'],
+      attributes: [{ name: 'foo', value: 'bar' }],
+      'property-to-keep': 'value',
+      'property-to-remove': 'yeah',
+    };
+    component.validate();
+    expect(component.errors).toEqual([]);
+  });
+});

--- a/src/organisms/gv-schema-form-group/index.ts
+++ b/src/organisms/gv-schema-form-group/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './gv-schema-form-group';

--- a/wc/gv-schema-form-group.js
+++ b/wc/gv-schema-form-group.js
@@ -1,0 +1,1 @@
+import '../src/organisms/gv-schema-form-group';


### PR DESCRIPTION
**Issue**
n/a 

**Description**

This component come from gv-shema-form but without submit / cancel feature. The goal of this one is to be used by angular inside reactive form (simply)

Component with medium term goal. The idea is to use it for all schema form needs in Gravitee console during the angularJs migration. Until it is replaced by native angular one

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-hxfpzpqgcp.chromatic.com)
<!-- Storybook placeholder end -->
