### PR TITLE
fix(gv-policy-studio): handle plans named with a special character

### DIFF
--- a/src/policy-studio/gv-policy-studio-menu/gv-policy-studio-menu.js
+++ b/src/policy-studio/gv-policy-studio-menu/gv-policy-studio-menu.js
@@ -630,7 +630,7 @@ export class GvPolicyStudioMenu extends LitElement {
 
         return html`${groups.map((group, index) => {
           let groupData = filteredData.filter((data) => data[groupKey] === group);
-          const listId = group ? group.replace(/\s+/g, '-').toLowerCase() : `group-${index}`;
+          const listId = group ? this._computeId(group) : `group-${index}`;
           const anchor = `#${listId}`;
           let right = html`<gv-state>${groupData.length}</gv-state>`;
           if (addHandler) {
@@ -654,7 +654,7 @@ export class GvPolicyStudioMenu extends LitElement {
         })}`;
       } else {
         if (listId == null) {
-          listId = type.replace(/\s+/g, '-').toLowerCase();
+          listId = this._computeId(type);
         }
         if (type === 'flows') {
           list = this._renderFlows(filteredData, type, isChild, listId, isOpen);
@@ -706,6 +706,19 @@ export class GvPolicyStudioMenu extends LitElement {
     e.preventDefault();
     e.stopPropagation();
     dispatchCustomEvent(this, 'add-flow');
+  }
+
+  /**
+   * Compute id from input based on the following rules:
+   *  - replace all non alphanumeric characters by `-`
+   *  - convert to lower case
+   *
+   * @param input {string} the input
+   * @returns {string} the computed id
+   * @private
+   */
+  _computeId(input) {
+    return input.replace(/[^a-zA-Z0-9]/g, '-').toLowerCase();
   }
 
   render() {

--- a/testing/resources/apim-definition.json
+++ b/testing/resources/apim-definition.json
@@ -372,6 +372,11 @@
           ]
         }
       ]
+    },
+    {
+      "id": "p-3",
+      "name": "Plan % containing $ special + characters",
+      "flows": []
     }
   ],
   "resources": [


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-983
https://github.com/gravitee-io/issues/issues/8909

**Description**

Handle plans named with a special character by properly removing all special characters when computing plan id
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-wubdzpsuhx.chromatic.com)
<!-- Storybook placeholder end -->
