### PR TITLE
fix(gv-chart-line): reduce max number of element in tooltip column

### DIFF
--- a/src/charts/gv-chart-line/gv-chart-line.js
+++ b/src/charts/gv-chart-line/gv-chart-line.js
@@ -92,7 +92,8 @@ export class GvChartLine extends ChartElement(LitElement) {
       },
       tooltip: {
         formatter: function () {
-          const nbCol = Math.trunc(this.points.filter((p) => p.y).length / 10);
+          const maxNumberOfElementPerColumn = 6;
+          const nbCol = Math.trunc(this.points.filter((p) => p.y).length / maxNumberOfElementPerColumn);
           let s = '<div><b>' + new Date(this.x).toLocaleString(getLanguage()) + '</b></div>';
           s += '<div class="' + (nbCol >= 2 ? 'tooltip tooltip-' + (nbCol > 5 ? 5 : nbCol) : '') + '">';
           if (


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-878
https://github.com/gravitee-io/issues/issues/5852

**Description**

Reduce the max number of elements in the tooltip columns to ensure everything is visible when there are a lot of series displayed

_Before_
![Capture d’écran 2023-03-07 à 08 56 04](https://user-images.githubusercontent.com/4112568/223363503-baee3df8-2063-4497-9c92-9961f42866a3.png)


_After_
![Capture d’écran 2023-03-07 à 09 01 28](https://user-images.githubusercontent.com/4112568/223363514-5d1a3e52-bd9c-43cc-8f04-b6aeedbfe823.png)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-uqcszjuplb.chromatic.com)
<!-- Storybook placeholder end -->
