### PR TITLE
Automatically run Chromatic when branch is pushed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,15 +230,6 @@ workflows:
           context: cicd-orchestrator
           requires:
             - build
-      - trigger-chromatic:
-          type: approval
-          requires:
-            - build
-            - lint-test
-          # Ignore this manual step and trigger chromatic automatically on `master`
-          filters:
-            branches:
-              ignore: master
       - chromatic-deployment:
           pre-steps:
             - keeper/env-export:
@@ -247,7 +238,7 @@ workflows:
           context: cicd-orchestrator
           requires:
             - build
-            - trigger-chromatic
+            - lint-test
       - release:
           pre-steps:
             - keeper/env-export:


### PR DESCRIPTION

**Issue**

NA

**Description**

We are now on a `Standard Plan` with 80 000 snapshots so let's use them
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-msnbaqwynh.chromatic.com)
<!-- Storybook placeholder end -->
