### PR TITLE
fix(gv-select): correctly display and place option list when used in a small container

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,8 @@
 import { jest } from '@jest/globals';
 
+// Mock Popper.js as there is no need to have it
+jest.mock('@popperjs/core');
+
 document.createRange = () => {
   const range = new Range();
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@codemirror/stream-parser": "^0.19.3",
     "@formatjs/intl-locale": "^2.4.40",
     "@formatjs/intl-relativetimeformat": "^9.3.2",
+    "@popperjs/core": "^2.11.7",
     "clipboard-copy": "^4.0.0",
     "codemirror-asciidoc": "^2.0.0",
     "date-fns": "^2.26.0",

--- a/src/atoms/gv-select/gv-select.stories.js
+++ b/src/atoms/gv-select/gv-select.stories.js
@@ -26,6 +26,7 @@ const conf = {
   css: `
     :host {
       height: 250px;
+      overflow: auto;
     }
 
     gv-select {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3926,6 +3926,7 @@ __metadata:
     "@formatjs/intl-locale": ^2.4.40
     "@formatjs/intl-relativetimeformat": ^9.3.2
     "@highcharts/map-collection": 2.0.1
+    "@popperjs/core": ^2.11.7
     "@semantic-release/changelog": 6.0.2
     "@semantic-release/git": 10.0.1
     "@storybook/addon-a11y": 6.5.16
@@ -4926,6 +4927,13 @@ __metadata:
   dependencies:
     "@octokit/openapi-types": ^11.2.0
   checksum: f122b9aee8f6baddd515e34a0913e73b21d4bc82d6ee59d77a8aaf01b4a02c10867dd013003d087a83dc96db23511893669015af6d30c27cece185e21cf1df89
+  languageName: node
+  linkType: hard
+
+"@popperjs/core@npm:^2.11.7":
+  version: 2.11.7
+  resolution: "@popperjs/core@npm:2.11.7"
+  checksum: 5b6553747899683452a1d28898c1b39173a4efd780e74360bfcda8eb42f1c5e819602769c81a10920fc68c881d07fb40429604517d499567eac079cfa6470f19
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8798,24 +8798,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001286":
-  version: 1.0.30001294
-  resolution: "caniuse-lite@npm:1.0.30001294"
-  checksum: 4e22649ef83781afbe6c81d6112ceac23c3ba29f91597ca1c14d323d5bfb646571edeb17436e76a29b07c8e9d75468655a2098a3e13dcc1438db47ff46fbb3ad
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001332":
-  version: 1.0.30001341
-  resolution: "caniuse-lite@npm:1.0.30001341"
-  checksum: 7262b093fb0bf49dbc5328418f5ce4e3dbb0b13e39c015f986ba1807634c123ac214efc94df7d095a336f57f86852b4b63ee61838f18dcc3a4a35f87b390c8f5
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001400":
-  version: 1.0.30001409
-  resolution: "caniuse-lite@npm:1.0.30001409"
-  checksum: d8581693491295ad8716db7ad6dccf74de970fc3ef4723b38bbc03b972862d363a9710c2a7582abcb741e1619164ddceca1df4dcf3d53d550e74829a9cb5ca82
+"caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001286, caniuse-lite@npm:^1.0.30001332, caniuse-lite@npm:^1.0.30001400":
+  version: 1.0.30001473
+  resolution: "caniuse-lite@npm:1.0.30001473"
+  checksum: 007ad17463612d38080fc59b5fa115ccb1016a1aff8daab92199a7cf8eb91cf987e85e7015cb0bca830ee2ef45f252a016c29a98a6497b334cceb038526b73f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-866
https://github.com/gravitee-io/issues/issues/8348

**Description**

Correctly display and place options list when used in a small container
Delegate option list placement to `popper.js` to ensure correct behaviour.


**Additional context**

Before
![image](https://user-images.githubusercontent.com/4112568/229049612-47fa7fdd-13c5-4147-84b6-56012003d31c.png)

After
![image](https://user-images.githubusercontent.com/4112568/229049526-f698e537-2cc3-4bd3-ae61-bec87d8a617d.png)



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-mwmvdfcmsr.chromatic.com)
<!-- Storybook placeholder end -->
