### PR TITLE
fix(gv-table): pagination issue when number of items don't divide by …

### DIFF
--- a/src/molecules/gv-table/gv-table.js
+++ b/src/molecules/gv-table/gv-table.js
@@ -605,12 +605,13 @@ export class GvTable extends withResizeObserver(LitElement) {
 
   _renderPagination() {
     if (this.options && this.options.paging && this._itemsProvider) {
+      const nbPages = Math.ceil(this._itemsProvider.length / this.options.paging);
       const paginationData = {
         first: 1,
-        last: this._itemsProvider.length / this.options.paging,
+        last: nbPages,
         total: this._itemsProvider.length,
         current_page: this._page,
-        total_pages: this._itemsProvider.length / this.options.paging,
+        total_pages: nbPages,
       };
       return html`<gv-pagination .data="${paginationData}" widget="true"></gv-pagination>`;
     }

--- a/src/molecules/gv-table/gv-table.stories.js
+++ b/src/molecules/gv-table/gv-table.stories.js
@@ -140,6 +140,10 @@ export const pagination = makeStory(conf, {
   items: [{ items: [...apiItems, ...apiItems], options: { ...apiOptions, paging: 2 }, title: 'APIs', order: 'name' }],
 });
 
+export const paginationPartialPage = makeStory(conf, {
+  items: [{ items: [...apiItems, ...apiItems], options: { ...apiOptions, paging: 5 }, title: 'APIs', order: 'name' }],
+});
+
 export const components = makeStory(conf, {
   items: [
     {


### PR DESCRIPTION
…the page size

**Issue**

https://gravitee.atlassian.net/browse/APIM-902

**Description**

Number of pages was a decimal number and pagination didn't work.
Rounding up the number of pages fixes the issue.

**Additional context**

I have added a story to reproduce the issue.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-psusaivmgy.chromatic.com)
<!-- Storybook placeholder end -->
