### PR TITLE
fix: dispatch input event to work with Angular's ngDefaultControl

### DIFF
--- a/src/organisms/gv-schema-form-group/gv-schema-form-group.js
+++ b/src/organisms/gv-schema-form-group/gv-schema-form-group.js
@@ -151,6 +151,7 @@ export class GvSchemaFormGroup extends LitElement {
     clearTimeout(this._changeTimeout);
     this._changeTimeout = setTimeout(() => {
       dispatchCustomEvent(this, 'change', { target: this, value: this._value, validation: this._validatorResults });
+      this.dispatchEvent(new Event('input', { bubbles: true, value: this._value }));
     }, 50);
   }
 


### PR DESCRIPTION


**Issue**

https://gravitee.atlassian.net/browse/APIM-1144

**Description**
Dispatch input event to work with Angular's ngDefaultControl

In some cases like copy and paste or select angular does not detect any change because it is waiting for an "input" event. Yes it's a fix on a hack already in place and commonly used in the portal. For the console this is temporary and soon replaced by native angular components

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-ssunaramxn.chromatic.com)
<!-- Storybook placeholder end -->
