### PR TITLE
fix: keep name text aline left when is long string

### DIFF
--- a/src/molecules/gv-tree/gv-tree.js
+++ b/src/molecules/gv-tree/gv-tree.js
@@ -90,7 +90,8 @@ export class GvTree extends LitElement {
 
         ul {
           display: block;
-          line-height: 2;
+          line-height: 1.5em;
+          text-align: left;
           list-style: none;
           margin: 0;
           padding: 0;

--- a/src/molecules/gv-tree/gv-tree.stories.js
+++ b/src/molecules/gv-tree/gv-tree.stories.js
@@ -34,7 +34,7 @@ const menuItems = [
       { name: 'page 21', value: 'p21' },
       { name: 'page 22', value: 'p22' },
       {
-        name: 'folder 21',
+        name: 'folder 21 - With long name to test line break',
         id: 'f21',
         children: [
           { name: 'page 211', value: 'p211' },


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-ui-components/issues/XXXXX

**Description**

before : 
![image](https://user-images.githubusercontent.com/4974420/236238632-2f202705-9955-4eed-82bb-f9db7ed1fc2a.png)
![image](https://user-images.githubusercontent.com/4974420/236239582-74afb930-3d1a-4908-91c0-89682f0221a0.png)

after : 
![image](https://user-images.githubusercontent.com/4974420/236239708-b757785d-fc28-4ab3-ba7e-02040bee0a3e.png)

![image](https://user-images.githubusercontent.com/4974420/236238783-6d84d8d8-5486-4e56-b2ea-ccad9acf364a.png)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-ubswmgsuug.chromatic.com)
<!-- Storybook placeholder end -->
