### PR TITLE
Use `hc-key` ref in map to ensure china is properly identified

### DIFF
--- a/src/charts/gv-chart-map/gv-chart-map.js
+++ b/src/charts/gv-chart-map/gv-chart-map.js
@@ -39,7 +39,7 @@ export class GvChartMap extends ChartElement(LitElement) {
     if (this._series && this._series.values) {
       Object.keys(this._series.values).forEach((k) => {
         if (!this.options.excludedKeys || (this.options.excludedKeys && !this.options.excludedKeys.includes(k))) {
-          data.push({ key: k, value: this._series.values[k] });
+          data.push({ key: k.toLowerCase(), value: this._series.values[k] });
         }
       });
     }
@@ -49,7 +49,7 @@ export class GvChartMap extends ChartElement(LitElement) {
       key = 'name';
       map = await import('@highcharts/map-collection/countries/' + zone.substring(0, 2) + '/' + zone + '-all.geo.json');
     } else {
-      key = 'hc-a2';
+      key = 'hc-key';
       map = await import('@highcharts/map-collection/custom/world.geo.json');
     }
     return {

--- a/src/charts/gv-chart-map/gv-chart-map.stories.js
+++ b/src/charts/gv-chart-map/gv-chart-map.stories.js
@@ -23,6 +23,7 @@ const series = {
     Unknown: 1000000,
     FR: 7567,
     GB: 1232,
+    CN: 5232,
     US: 2000,
     RU: 922,
     IT: 3000,


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-909
https://github.com/gravitee-io/issues/issues/8230

**Description**

Use `hc-key` ref in map to ensure china is properly identified

Quote from https://www.highcharts.com/forum/viewtopic.php?t=33579#p117910:

> 'hc-a2' has CN assigned to 2 regions: 'China' and 'Cyprus No Mans Area'.
> 'hc-a2' in custom/world.js map is not a unique key property. Use 'hc-key' instead.


**Additional context**

Before:
![image](https://user-images.githubusercontent.com/4112568/236504618-11d54b85-972c-431a-85ff-55e8841a4abd.png)

After: 
![image](https://user-images.githubusercontent.com/4112568/236504235-54613ffb-6d94-48e9-8664-aa53eb5f902c.png)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-pwuznzlxcr.chromatic.com)
<!-- Storybook placeholder end -->
