### PR TITLE
feat: use gioConfig.banner.text as description by default

### DIFF
--- a/src/organisms/gv-schema-form-control/gv-schema-form-control.js
+++ b/src/organisms/gv-schema-form-control/gv-schema-form-control.js
@@ -213,8 +213,8 @@ export class GvSchemaFormControl extends UpdateAfterBrowser(LitElement) {
       element.type = 'password';
     }
 
-    if (this.control.description) {
-      element.description = this.control.description;
+    if (this.control.description || this.control.gioConfig?.banner) {
+      element.description = this.control.gioConfig?.banner?.text ?? this.control.description;
     }
 
     if (placeholder != null) {

--- a/src/organisms/gv-schema-form-group/gv-schema-form-group.stories.js
+++ b/src/organisms/gv-schema-form-group/gv-schema-form-group.stories.js
@@ -18,6 +18,7 @@ import { makeStory } from '../../../testing/lib/make-story';
 import mixed from '../../../testing/resources/schemas/mixed.json';
 import htmlToJson from '../../../testing/resources/schemas/html-to-json.json';
 import httpConnector from '../../../testing/resources/schemas/http-connector.json';
+import policyCache from '../../../testing/resources/schemas/policy-cache.json';
 import { fetch } from 'whatwg-fetch';
 import grammar from '../../../testing/resources/el-grammar.json';
 import resourceCacheRedis from '../../../testing/resources/schemas/resource-cache-redis.json';
@@ -131,6 +132,10 @@ export const HTMLToJson = makeStory(conf, {
 
 export const HttpConnector = makeStory(conf, {
   items: [{ schema: httpConnector }],
+});
+
+export const PolicyCache = makeStory(conf, {
+  items: [{ schema: policyCache }],
 });
 
 export const ResourceCacheRedis = makeStory(conf, {

--- a/testing/resources/schemas/policy-cache.json
+++ b/testing/resources/schemas/policy-cache.json
@@ -1,6 +1,7 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "id": "urn:jsonschema:io:gravitee:policy:cache:configuration:CachePolicyConfiguration",
+  "additionalProperties": false,
   "properties": {
     "cacheName": {
       "title": "Cache name",
@@ -9,20 +10,47 @@
       "x-schema-form": {
         "event": {
           "name": "fetch-resources",
-          "types": ["cache"]
+          "regexTypes": "^cache"
         }
       }
     },
     "key": {
       "title": "Key",
-      "description": "The key used to store the element (support EL).",
-      "type": "string"
+      "description": "The key used to store the element (Support EL).",
+      "type": "string",
+      "x-schema-form": {
+        "expression-language": true
+      }
     },
     "timeToLiveSeconds": {
       "title": "Time to live (in seconds)",
       "default": 600,
       "description": "Time to live of the element put in cache (Default to 10 minutes).",
       "type": "integer"
+    },
+    "methods": {
+      "title": "Methods to cache",
+      "description": "Select which method you want to cache.",
+      "type": "array",
+      "default": ["GET", "OPTIONS", "HEAD"],
+      "items": {
+        "type": "string",
+        "enum": ["CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE"]
+      }
+    },
+    "responseCondition": {
+      "title": "Response Condition",
+      "description": "(Support EL)",
+      "type": "string",
+      "x-schema-form": {
+        "expression-language": true
+      },
+      "gioConfig": {
+        "banner": {
+          "title": "Response Condition",
+          "text": "Add an extra condition (with Expression Language) based on the response to activate cache.<br>For example use <strong>{#upstreamResponse.status == 200}</strong> to only cache 200 responses status. By default, 2xx only are cached.<br> \uD83D\uDEA8 <code>upstreamResponse.content</code> is not supported."
+        }
+      }
     },
     "useResponseCacheHeaders": {
       "title": "Use response headers",
@@ -31,10 +59,15 @@
     },
     "scope": {
       "title": "Scope",
-      "description": "Cached response can be set for a single consumer (application) or for all consumers.<br><strong>WARNING:</strong> Please be aware that by using an \"API\" scope, data will be shared between all consumers!",
       "type": "string",
       "default": "APPLICATION",
-      "enum": ["API", "APPLICATION"]
+      "enum": ["API", "APPLICATION"],
+      "gioConfig": {
+        "banner": {
+          "title": "Scope",
+          "text": "Cached response can be set for a single consumer (application) or for all consumers.<br><strong>WARNING:</strong> Please be aware that by using an \"API\" scope, data will be shared between all consumers!"
+        }
+      }
     }
   },
   "required": ["cacheName", "timeToLiveSeconds"]


### PR DESCRIPTION

**Issue**

https://gravitee.atlassian.net/browse/APIM-2085

**Description**

So that the plugin's json schema is compatible with the 2 json-schema components. I add some capabilities to this one.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-dtvzbejpwg.chromatic.com)
<!-- Storybook placeholder end -->
