### PR TITLE
fix: remove nesting of folder arrows

### DIFF
--- a/src/molecules/gv-tree/gv-tree.js
+++ b/src/molecules/gv-tree/gv-tree.js
@@ -86,6 +86,7 @@ export class GvTree extends LitElement {
 
         .main-tree-menu > ul {
           position: relative;
+          padding-right: 0.5em;
         }
 
         ul {
@@ -99,7 +100,7 @@ export class GvTree extends LitElement {
 
         ul li {
           display: block;
-          padding: 0.5em 0.5em 0.5em 1em;
+          padding: 0.5em 0 0.5em 1em;
         }
 
         ul li ul {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3130

**Description**

Remove nesting of folders in Portal documentation file tree.

![Screenshot 2023-11-03 at 15 11 41](https://github.com/gravitee-io/gravitee-ui-components/assets/42294616/61e79797-cb69-4f34-95a9-1ca602b5caea)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-hszqznymwx.chromatic.com)
<!-- Storybook placeholder end -->
