### PR TITLE
fix: remove useless space before button

### DIFF
--- a/src/molecules/gv-option/gv-option.js
+++ b/src/molecules/gv-option/gv-option.js
@@ -205,7 +205,7 @@ export class GvOption extends LitElement {
   _renderOption(option, index) {
     const isActive = this.isActive(option);
     const outlined = this.outlined || (!isActive && this._hasDescription);
-    return html` <gv-button
+    return html`<gv-button
       .icon=${ifDefined(!this._hasDescription ? option.icon : null)}
       .iconRight=${ifDefined(!option.icon && option.iconRight ? option.iconRight : null)}
       .title="${ifDefined(option.title)}"


### PR DESCRIPTION
**Issue**

Before : 
![Capture d’écran 2023-11-29 à 09 37 14](https://github.com/gravitee-io/gravitee-ui-components/assets/1457497/eba913e8-2eb8-4b29-8294-eabbc09162dd)

After : 
![Capture d’écran 2023-11-29 à 09 37 03](https://github.com/gravitee-io/gravitee-ui-components/assets/1457497/5ac36498-d152-4d2f-9174-a623cd659c1e)

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

