### PR TITLE
Compute flow name to reflect gateway behaviourr

### DIFF
--- a/src/lib/studio.js
+++ b/src/lib/studio.js
@@ -120,14 +120,23 @@ export function getFlowTitle(flow, collectionName, withMethods = true, draggable
         rendering.push(html`<div class="${classMap(classes)}">${flow.name}</div>`);
       }
     } else if (flow['path-operator']) {
-      const path = flow['path-operator'].path || '/';
-      if (path) {
-        const pathWithOperator = flow['path-operator'].operator === 'STARTS_WITH' ? `${path.endsWith('/') ? path : `${path}/`}**` : path;
-        if (flow._dirty) {
-          rendering.push(html`<div class="${classMap(classes)}"><mark>${pathWithOperator}</mark></div>`);
-        } else {
-          rendering.push(html`<div class="${classMap(classes)}">${pathWithOperator}</div>`);
-        }
+      let pathWithOperator = '/';
+      if (flow['path-operator'].path && flow['path-operator'].path.length > 1) {
+        flow['path-operator'].path.split('/').forEach((pathPart) => {
+          if (pathPart !== '') {
+            pathWithOperator += `${pathPart}/`;
+          }
+        });
+        pathWithOperator = pathWithOperator.substring(0, pathWithOperator.length - 1);
+      }
+      if (flow['path-operator'].operator === 'STARTS_WITH') {
+        pathWithOperator += '**';
+      }
+
+      if (flow._dirty) {
+        rendering.push(html`<div class="${classMap(classes)}"><mark>${pathWithOperator}</mark></div>`);
+      } else {
+        rendering.push(html`<div class="${classMap(classes)}">${pathWithOperator}</div>`);
       }
     }
 

--- a/src/organisms/gv-schema-form/gv-schema-form.test.js
+++ b/src/organisms/gv-schema-form/gv-schema-form.test.js
@@ -250,7 +250,7 @@ describe('S C H E M A  F O R M', () => {
           path: ['path-operator', 'path'],
           property: 'instance.path-operator.path',
           schema: {
-            description: 'The path of flow (must start by /)',
+            description: 'The path of flow (must start by /). Trailing slash is ignored.',
             pattern: '^/',
             title: 'Path',
             type: 'string',

--- a/src/policy-studio/gv-design/gv-design.test.js
+++ b/src/policy-studio/gv-design/gv-design.test.js
@@ -151,7 +151,7 @@ describe('D E S I G N', () => {
               },
               path: {
                 title: 'Path',
-                description: 'The path of flow (must start by /)',
+                description: 'The path of flow (must start by /). Trailing slash is ignored.',
                 type: 'string',
                 pattern: '^/',
                 default: '/',

--- a/src/policy-studio/gv-policy-studio/gv-policy-studio.test.js
+++ b/src/policy-studio/gv-policy-studio/gv-policy-studio.test.js
@@ -181,7 +181,7 @@ describe('P O L I C Y  S T U D I O', () => {
               },
               path: {
                 title: 'Path',
-                description: 'The path of flow (must start by /)',
+                description: 'The path of flow (must start by /). Trailing slash is ignored.',
                 type: 'string',
                 pattern: '^/',
                 default: '/',

--- a/testing/resources/schemas/apim-flow.json
+++ b/testing/resources/schemas/apim-flow.json
@@ -26,7 +26,7 @@
         },
         "path": {
           "title": "Path",
-          "description": "The path of flow (must start by /)",
+          "description": "The path of flow (must start by /). Trailing slash is ignored.",
           "type": "string",
           "pattern": "^/",
           "default": "/"

--- a/testing/resources/schemas/fields-dependencies.json
+++ b/testing/resources/schemas/fields-dependencies.json
@@ -25,7 +25,7 @@
         },
         "path": {
           "title": "Path",
-          "description": "The path of flow (must start by /)",
+          "description": "The path of flow (must start by /). Trailing slash is ignored.",
           "type": "string",
           "pattern": "^/",
           "x-schema-form": {

--- a/testing/resources/schemas/mixed.json
+++ b/testing/resources/schemas/mixed.json
@@ -61,7 +61,7 @@
         },
         "path": {
           "title": "Path",
-          "description": "The path of flow (must start by /)",
+          "description": "The path of flow (must start by /). Trailing slash is ignored.",
           "type": "string",
           "pattern": "^/",
           "x-schema-form": {


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3569

**Description**

Use the same kind of algorithm as in the gateway to build the flow name. This way, it will reflect a little bit better what the user can expect.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-ghrfjsymyp.chromatic.com)
<!-- Storybook placeholder end -->
