### PR TITLE
feat: collapse gv-tree by default

### DIFF
--- a/src/molecules/gv-tree/gv-tree.js
+++ b/src/molecules/gv-tree/gv-tree.js
@@ -31,6 +31,7 @@ import { classMap } from 'lit/directives/class-map.js';
  *
  * @attr {Array} items - list of items and subitems to be displayed in the menu MenuItem: {name: String, value: any, children: Array<MenuItem>}
  * @attr {Boolean} closed - allows to close the menu
+ * @attr {String} closedTooltip - tooltip shown when closed and hovering over icon
  * @attr {Object} selectedItem - the item selected
  *
  * @cssprop {Color} [--gv-tree--bgc=var(--gv-theme-neutral-color-lightest, #ffffff)] - Background color
@@ -44,6 +45,7 @@ export class GvTree extends LitElement {
     return {
       items: { type: Array },
       closed: { type: Boolean, reflect: true },
+      closedTooltip: { type: String },
       selectedItem: { type: Object },
     };
   }
@@ -177,7 +179,8 @@ export class GvTree extends LitElement {
 
   constructor() {
     super();
-    this.closed = false;
+    this.closed = true;
+    this.closedTooltip = 'Expand';
   }
 
   _onSelect(menuItem, e) {
@@ -233,18 +236,23 @@ export class GvTree extends LitElement {
     dispatchCustomEvent(this, 'toggle', { closed: this.closed });
   }
 
+  _getIcon() {
+    const innerContent = this.closed
+      ? html`<gv-popover position="right">
+          <gv-icon shape="text:menu" @click=${this._toggleMenu}></gv-icon>
+          <div slot="popover">${this.closedTooltip}</div>
+        </gv-popover>`
+      : html` <gv-icon shape="navigation:angle-double-left" @click=${this._toggleMenu}></gv-icon>`;
+    return html`<div class="switch">${innerContent}</div>`;
+  }
+
   render() {
     const classes = {
       tree: true,
       closed: this.closed,
     };
     return html`
-      <div class=${classMap(classes)}>
-        <div class="switch">
-          <gv-icon shape="${this.closed ? 'text:menu' : 'navigation:angle-double-left'}" @click=${this._toggleMenu}></gv-icon>
-        </div>
-        ${html`<div class="main-tree-menu">${this._getMenu(this.items)}</div>`}
-      </div>
+      <div class=${classMap(classes)}>${this._getIcon()} ${html`<div class="main-tree-menu">${this._getMenu(this.items)}</div>`}</div>
     `;
   }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3740

**Description**

The `gv-tree` menu is to be closed by default + add attribute for tooltip on closed

![Screenshot 2024-01-29 at 16 12 18](https://github.com/gravitee-io/gravitee-ui-components/assets/42294616/787e7d5c-4803-41d4-acc9-ec51893913fc)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-zavgilaeyp.chromatic.com)
<!-- Storybook placeholder end -->
