### PR TITLE
fix: keep "touch" and "dirty" states of gv-schema-form when using policy studio policy and documentation 

### DIFF
--- a/src/organisms/gv-schema-form/gv-schema-form.js
+++ b/src/organisms/gv-schema-form/gv-schema-form.js
@@ -57,7 +57,7 @@ export class GvSchemaForm extends LitElement {
       validateOnRender: { type: Boolean, attribute: 'validate-on-render' },
       _validatorResults: { type: Object },
       skeleton: { type: Boolean, reflect: true },
-      _touch: { type: Boolean },
+      touch: { type: Boolean },
       readonly: { type: Boolean, reflect: true },
       scrollable: { type: Boolean, reflect: true },
       groups: { type: Array },
@@ -71,7 +71,7 @@ export class GvSchemaForm extends LitElement {
     this.submitLabel = 'Ok';
     this.hasHeader = false;
     this.hasFooter = false;
-    this._touch = false;
+    this.touch = false;
     this._validator = new Validator();
     this._validatorResults = {};
     this._ignoreProperties = [];
@@ -109,7 +109,7 @@ export class GvSchemaForm extends LitElement {
 
   reset(values = null) {
     this._values = deepClone(values || this._initialValues);
-    this._touch = false;
+    this.touch = false;
     this._setDirty(false);
     this.getControls().forEach((s) => {
       s.requestUpdate();
@@ -141,7 +141,7 @@ export class GvSchemaForm extends LitElement {
     if (this.isValid()) {
       this._initialValues = deepClone(this._values);
       this.dirty = false;
-      this._touch = false;
+      this.touch = false;
       dispatchCustomEvent(this, 'submit', { values: this._values, validatorResults });
     } else {
       dispatchCustomEvent(this, 'error', { values: this._values, validatorResults });
@@ -153,7 +153,7 @@ export class GvSchemaForm extends LitElement {
   }
 
   _setTouch(touch = true) {
-    this._touch = !!touch;
+    this.touch = !!touch;
   }
 
   confirm(force = false) {
@@ -489,7 +489,7 @@ export class GvSchemaForm extends LitElement {
   }
 
   isTouch() {
-    return this._touch || (this.dirty && this.validateOnRender);
+    return this.touch || (this.dirty && this.validateOnRender);
   }
 
   canSubmit() {

--- a/src/organisms/gv-schema-form/gv-schema-form.test.js
+++ b/src/organisms/gv-schema-form/gv-schema-form.test.js
@@ -324,7 +324,7 @@ describe('S C H E M A  F O R M', () => {
     component.validate();
 
     component.updateComplete.then(() => {
-      component._touch = true;
+      component.touch = true;
       expect(component.canSubmit()).toBeTruthy();
       done();
     });

--- a/src/policy-studio/gv-design/gv-design.js
+++ b/src/policy-studio/gv-design/gv-design.js
@@ -982,6 +982,7 @@ export class GvDesign extends KeyboardElement(LitElement) {
   }
 
   _renderFlowStepForm(readonlyMode) {
+    const flowStepForm = this._getFlowStepForm();
     const values = this._currentFlowStep._values || this._currentFlowStep._initialValues;
 
     const groups = [
@@ -999,6 +1000,8 @@ export class GvDesign extends KeyboardElement(LitElement) {
                 .id="${FLOW_STEP_FORM_ID}"
                 .schema="${this._flowStepSchema}"
                 .icon="design:edit"
+                .touch="${flowStepForm?.touch}"
+                .dirty="${flowStepForm?._dirty}"
                 has-header
                 validate-on-render
                 .values="${values}"

--- a/src/policy-studio/gv-policy-studio/gv-policy-studio.js
+++ b/src/policy-studio/gv-policy-studio/gv-policy-studio.js
@@ -1093,6 +1093,7 @@ export class GvPolicyStudio extends KeyboardElement(LitElement) {
   }
 
   _renderFlowStepForm(readonlyMode) {
+    const flowStepForm = this._getFlowStepForm();
     const values = this._currentFlowStep._values || this._currentFlowStep._initialValues;
 
     const groups = [
@@ -1110,6 +1111,8 @@ export class GvPolicyStudio extends KeyboardElement(LitElement) {
                 .id="${FLOW_STEP_FORM_ID}"
                 .schema="${this._flowStepSchema}"
                 .icon="design:edit"
+                .touch="${flowStepForm?.touch}"
+                .dirty="${flowStepForm?._dirty}"
                 has-header
                 validate-on-render
                 .values="${values}"


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5483

**Description**

In policy studio when we update the schema form the submit button is disabled. After that if we open or close the policy documentation the button become disabled

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-jhjjoqeenj.chromatic.com)
<!-- Storybook placeholder end -->
