### PR TITLE
refactor: change how sanitize from DOMPurify is imported

### DIFF
--- a/src/lib/text-format.js
+++ b/src/lib/text-format.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { sanitize } from 'dompurify';
+import DOMPurify from 'dompurify';
 
 export async function loadAsciiDoctor() {
   let _gvAsciidoctor = window._gvAsciidoctor;
@@ -51,7 +51,7 @@ export function toDom(text, type = 'adoc', small = false) {
           // href="[SERVER_BASE]/#a_link" i.e. href="https://apim-master-portal.cloud.gravitee.io/#a_link"
           .replace(/href="#/g, `href="${window.location.href}#`);
         // Sanitize HTML content to avoid XSS attacks
-        innerHTML = sanitize(htmlContent);
+        innerHTML = DOMPurify.sanitize(htmlContent);
       } else {
         throw new Error(`Library not found for type : '${type}' | ${text}`);
       }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-ui-components/issues/XXXXX

**Description**

When upgrading `portal-webui` to Angular 19, a compile error was thrown:

```
 [ERROR] No matching export in "node_modules/@gravitee/ui-components/node_modules/dompurify/dist/purify.es.mjs" for import "sanitize"

    node_modules/@gravitee/ui-components/src/lib/text-format.js:43:9:
      43 │ import { sanitize } from 'dompurify';
         ╵          ~~~~~~~~

```

To fix the error, the import is handled differently in `text-format.js`.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-gorqhmkzvw.chromatic.com)
<!-- Storybook placeholder end -->
