### PR TITLE
chore: bump jsonschema to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "date-fns": "^2.26.0",
     "dompurify": "3.1.5",
     "jdenticon": "^3.1.0",
-    "jsonschema": "1.4.1",
+    "jsonschema": "1.5.0",
     "lit": "^2.0.2",
     "object-path": "^0.11.8",
     "resize-observer-polyfill": "^1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4113,7 +4113,7 @@ __metadata:
     is-ci: 3.0.1
     jdenticon: ^3.1.0
     jest: 27.5.1
-    jsonschema: 1.4.1
+    jsonschema: 1.5.0
     license-check-and-add: 4.0.5
     lint-staged: 12.5.0
     lit: ^2.0.2
@@ -16106,10 +16106,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonschema@npm:1.4.1":
-  version: 1.4.1
-  resolution: "jsonschema@npm:1.4.1"
-  checksum: 1ef02a6cd9bc32241ec86bbf1300bdbc3b5f2d8df6eb795517cf7d1cd9909e7beba1e54fdf73990fd66be98a182bda9add9607296b0cb00b1348212988e424b2
+"jsonschema@npm:1.5.0":
+  version: 1.5.0
+  resolution: "jsonschema@npm:1.5.0"
+  checksum: 170b9c375967bc135f4d029fedc31f5686f2c3bb07e7472cebddbb907b5369bf75a1a50287d6af9c31f61c76fe0b7786e78044c188aaddd329b77d856475e6db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12448

**Description**

Resolve issue in Console:

```
./node_modules/jsonschema/lib/helpers.js:3:10-24 - Error: Module not found: Error: Can't resolve 'url' in '/gravitee-api-management/gravitee-apim-console-webui/node_modules/jsonschema/lib'



BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.

This is no longer the case. Verify if you need this module and configure a polyfill for it.



If you want to include a polyfill, you need to:

        - add a fallback 'resolve.fallback: { "url": require.resolve("url/") }'

        - install 'url'

If you don't want to include a polyfill, you can use an empty module like this:

        resolve.fallback: { "url": false }
```

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

