### PR TITLE
fix(portal): prevent API card layout break on long version strings

### DIFF
--- a/src/molecules/gv-card-full/gv-card-full.js
+++ b/src/molecules/gv-card-full/gv-card-full.js
@@ -94,9 +94,11 @@ export class GvCardFull extends ItemResource(LitElement) {
 
         .card > div {
           display: flex;
+          min-width: 0;
         }
 
         .image {
+          flex: 0 0 auto;
           min-height: 65px;
           min-width: 0;
           position: relative;
@@ -109,6 +111,9 @@ export class GvCardFull extends ItemResource(LitElement) {
           text-transform: capitalize;
           font-weight: bold;
           padding-bottom: 5px;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
         }
 
         .owner {
@@ -118,17 +123,29 @@ export class GvCardFull extends ItemResource(LitElement) {
           display: flex;
           padding-bottom: 2px;
           line-height: initial;
+          min-width: 0;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
         }
 
         .content {
           flex: 1;
+          min-width: 0;
+          overflow: hidden;
           padding: 0 10px 10px 10px;
         }
 
         .version {
+          flex: 0 1 auto;
+          min-width: 0;
+          max-width: 45%;
           color: var(--gv-theme-neutral-color-dark, #d9d9d9);
           padding: 10px 8px;
           font-size: var(--gv-theme-font-size-s, 12px);
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
         }
 
         .description {
@@ -201,6 +218,7 @@ export class GvCardFull extends ItemResource(LitElement) {
   render() {
     const title = getTitle(this._item);
     const owner = getOwner(this._item);
+    const version = getVersion(this._item);
     const classes = { error: this._error || this._empty, card: true };
     return html`<div class="${classMap(classes)}" title="${title}" @click="${this._onClick}">
       <div class="${classMap({ skeleton: this._skeleton })}">
@@ -212,7 +230,7 @@ export class GvCardFull extends ItemResource(LitElement) {
             : ''}
           <div class="states">${this._renderStates()}</div>
         </div>
-        <div class="version"><span class="${classMap({ skeleton: this._skeleton })}">${getVersion(this._item)}</span></div>
+        <div class="version" title="${version}"><span class="${classMap({ skeleton: this._skeleton })}">${version}</span></div>
       </div>
       <div
         class="${classMap({ skeleton: this._skeleton, description: true })}"

--- a/src/molecules/gv-card-full/gv-card-full.stories.js
+++ b/src/molecules/gv-card-full/gv-card-full.stories.js
@@ -75,6 +75,16 @@ const apiItems = [
       owner,
     },
   },
+  {
+    item: {
+      name: 'Supernova with long version',
+      description,
+      version: '1.0.757-task_ABC-123_DEF-456_allow_pipe_dash-SNAPSHOT',
+      labels,
+      states: [{ value: 'running', major: true }],
+      owner: { display_name: 'ContentHubAdmin' },
+    },
+  },
 ];
 
 const appItems = [{ item: application }, { item: application, metrics: applicationMetrics }];

--- a/src/molecules/gv-card/gv-card.js
+++ b/src/molecules/gv-card/gv-card.js
@@ -94,10 +94,13 @@ export class GvCard extends ItemResource(LitElement) {
           font-weight: bold;
           white-space: nowrap;
           overflow: hidden;
+          text-overflow: ellipsis;
+          max-width: 100%;
         }
 
         .content {
           flex: 1;
+          min-width: 0;
           padding: 6px 16px 12px;
         }
 
@@ -105,7 +108,13 @@ export class GvCard extends ItemResource(LitElement) {
           color: var(--gv-theme-neutral-color-dark, #d9d9d9);
           top: 0.4rem;
           right: 0.4rem;
+          left: 0.4rem;
           position: absolute;
+          max-width: calc(100% - 0.8rem);
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+          text-align: right;
         }
       `,
       skeleton,
@@ -114,8 +123,9 @@ export class GvCard extends ItemResource(LitElement) {
 
   render() {
     const title = getTitle(this._item);
+    const version = getVersion(this._item);
     return html`<div class="card" title="${title}">
-      <span class="${classMap({ skeleton: this._skeleton, version: true })}">${getVersion(this._item)}</span>
+      <span class="${classMap({ skeleton: this._skeleton, version: true })}" title="${version}">${version}</span>
       <div class="${classMap({ image: true, skeleton: this._skeleton })}">${this._renderImage()}</div>
 
       <div class="${classMap({ content: true, empty: this._error || this._empty })}">


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13736

**Description**

gv-card-full renders the API image, title/owner/states, and version in a horizontal flex row. The version element had no overflow constraints, so long strings expanded the row and collapsed the .content area.

Compact gv-card had the same class of issue for long versions in the Featured sidebar.

Solution
Add min-width: 0 on flex containers so children can shrink correctly
Apply overflow: hidden, white-space: nowrap, and text-overflow: ellipsis on title, owner, and version
Cap version width in gv-card-full (max-width: 45%) so title/owner/states keep space
Add native title attribute on version for full text on hover


Before fix:
<img width="1327" height="617" alt="image" src="https://github.com/user-attachments/assets/d8176933-c792-40f2-ac79-3ecdd355cca1" />

After fix: 
<img width="1327" height="617" alt="image" src="https://github.com/user-attachments/assets/41532d0d-d75e-4023-95bf-bdc0244a1bbd" />


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-klyknmjyfd.chromatic.com)
<!-- Storybook placeholder end -->
