### PR TITLE
fix(schema-form): stop crash + surface root oneOf errors

### DIFF
--- a/src/lib/schema-form.js
+++ b/src/lib/schema-form.js
@@ -42,3 +42,47 @@ export function canGrid(schema) {
   const keys = Object.keys(schema.properties || {});
   return keys.length > 2 && keys.filter((key) => _canInline(schema, key)).length === keys.length;
 }
+
+const FORM_LEVEL_PREFIXES = {
+  oneOf: 'Select exactly one of',
+  anyOf: 'Select at least one of',
+};
+
+/**
+ * Returns validation errors that don't map to any single control: root
+ * oneOf/anyOf failures report property === 'instance' with an array argument.
+ * They would otherwise be silently dropped by gv-schema-form-control, leaving
+ * the user with no feedback on why the form is invalid.
+ */
+export function getFormLevelErrors(errors) {
+  if (!Array.isArray(errors)) return [];
+  return errors.filter(
+    (error) =>
+      error != null && error.property === 'instance' && (error.name === 'oneOf' || error.name === 'anyOf') && Array.isArray(error.argument),
+  );
+}
+
+/**
+ * `jsonschema` builds error.argument as an array of JSON-stringified titles
+ * (e.g. '"My title "'). Surface them as a readable comma list rather than the
+ * raw `JSON.stringify`'d message.
+ */
+export function formatFormLevelError(error) {
+  const titles = error.argument
+    .map(stripJsonStringifyWrap)
+    .map((title) => title.trim())
+    .filter((title) => title.length > 0);
+  if (titles.length === 0) {
+    return error.message;
+  }
+  const prefix = FORM_LEVEL_PREFIXES[error.name];
+  return prefix ? `${prefix}: ${titles.join(', ')}` : titles.join(', ');
+}
+
+// Strips the surrounding double-quotes JSON.stringify(title) adds, while
+// leaving non-string entries (e.g. '<#/defs/Foo>', '[subschema 0]') intact.
+function stripJsonStringifyWrap(entry) {
+  if (typeof entry !== 'string') return String(entry);
+  const match = entry.match(/^"(.*)"$/s);
+  return match ? match[1] : entry;
+}

--- a/src/organisms/gv-schema-form-control/gv-schema-form-control.js
+++ b/src/organisms/gv-schema-form-control/gv-schema-form-control.js
@@ -328,7 +328,7 @@ export class GvSchemaFormControl extends UpdateAfterBrowser(LitElement) {
       this._updateProperties(this.getControl());
     }
 
-    if (changedProperties.has('errors') && this.errors != null) {
+    if (changedProperties.has('errors') && Array.isArray(this.errors)) {
       // Set errors to complex controls
       this.getControls().forEach((control) => {
         control.errors = this.errors;
@@ -339,11 +339,19 @@ export class GvSchemaFormControl extends UpdateAfterBrowser(LitElement) {
       errorContainer.forEach((container) => (container.innerHTML = ''));
       this.errors.forEach((error) => {
         const key = error.property === 'instance' ? error.argument : error.property.replace('instance.', '');
-        const errorContainer = this.shadowRoot.querySelector(`[id="${key}-error"]`);
+        // oneOf/anyOf errors expose `argument` as an array of branch descriptors
+        // with no single field to attach to. Skip those rather than build an
+        // invalid CSS selector that throws DOMException and aborts shouldUpdate,
+        // leaving the form unrendered.
+        if (typeof key !== 'string' || key === '') {
+          return;
+        }
+        const escapedKey = typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(key) : key.replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+        const errorContainer = this.shadowRoot.querySelector(`[id="${escapedKey}-error"]`);
         if (errorContainer) {
           const message = document.createElement('gv-input-message');
           message.innerHTML = this.formatErrorMessage(error);
-          message.level = 'warn';
+          message.level = 'warning';
           errorContainer.appendChild(message);
         }
       });

--- a/src/organisms/gv-schema-form-group/gv-schema-form-group.js
+++ b/src/organisms/gv-schema-form-group/gv-schema-form-group.js
@@ -21,6 +21,8 @@ import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { Validator } from 'jsonschema';
 import { empty } from '../../styles/empty';
+import { formatFormLevelError, getFormLevelErrors } from '../../lib/schema-form';
+import '../../atoms/gv-input-message';
 import '../gv-schema-form-control';
 
 /**
@@ -480,6 +482,9 @@ export class GvSchemaFormGroup extends LitElement {
   render() {
     return html`
       <div class="${classMap({ container: true, confirm: this._confirm })}">
+        ${getFormLevelErrors(this.errors).map(
+          (error) => html`<gv-input-message class="form-level-error" level="warning">${formatFormLevelError(error)}</gv-input-message>`,
+        )}
         <div class="content">${this.schema != null ? this._renderPart() : html``}</div>
       </div>
     `;
@@ -524,6 +529,10 @@ export class GvSchemaFormGroup extends LitElement {
         .footer,
         .content {
           background-color: var(--bgc);
+        }
+
+        .form-level-error {
+          margin: 0.4rem;
         }
 
         .content {

--- a/src/organisms/gv-schema-form-group/gv-schema-form-group.test.js
+++ b/src/organisms/gv-schema-form-group/gv-schema-form-group.test.js
@@ -15,6 +15,13 @@
  */
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { Page, querySelector, since } from '../../../testing/lib/test-utils';
+import {
+  expectControlGuardsHoldWithRootOneOf,
+  expectNoThrowOnNonArrayErrors,
+  expectRootOneOfBanner,
+  rootOneOfSchema,
+  rootOneOfWithPropertiesSchema,
+} from '../../../testing/lib/schema-form-test-utils';
 import './gv-schema-form-group';
 import mixed from '../../../testing/resources/schemas/mixed.json';
 import fieldsDependencies from '../../../testing/resources/schemas/fields-dependencies.json';
@@ -514,5 +521,29 @@ describe('S C H E M A  F O R M  G R O U P', () => {
     };
     component.validate();
     expect(component.errors).toEqual([]);
+  });
+
+  test('should not throw when errors is a non-array value', async () => {
+    // Use a minimal schema so the test doesn't churn the 21-control mixed tree.
+    component.schema = { type: 'object', properties: { foo: { type: 'string' } } };
+    component.value = {};
+    await component.updateComplete;
+    await expectNoThrowOnNonArrayErrors(component);
+  });
+
+  test('should render a banner and not throw on root oneOf failures', async () => {
+    component.schema = rootOneOfSchema;
+    component.value = {};
+    component._setTouch(true);
+    await component.updateComplete;
+    await expectRootOneOfBanner(component);
+  });
+
+  test('should not crash when root oneOf coexists with rendered controls', async () => {
+    component.schema = rootOneOfWithPropertiesSchema;
+    component.value = {};
+    component._setTouch(true);
+    await component.updateComplete;
+    await expectControlGuardsHoldWithRootOneOf(component);
   });
 });

--- a/src/organisms/gv-schema-form/gv-schema-form.js
+++ b/src/organisms/gv-schema-form/gv-schema-form.js
@@ -21,6 +21,8 @@ import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { Validator } from 'jsonschema';
 import { empty } from '../../styles/empty';
+import { formatFormLevelError, getFormLevelErrors } from '../../lib/schema-form';
+import '../../atoms/gv-input-message';
 import '../gv-schema-form-control';
 
 /**
@@ -575,6 +577,9 @@ export class GvSchemaForm extends LitElement {
               </div>
             `
           : ''}
+        ${getFormLevelErrors(this.errors).map(
+          (error) => html`<gv-input-message class="form-level-error" level="warning">${formatFormLevelError(error)}</gv-input-message>`,
+        )}
         <div class="content">${this.schema != null ? this._renderPart() : html``}</div>
         ${this.hasFooter === true && this.readonly !== true
           ? html`
@@ -632,6 +637,10 @@ export class GvSchemaForm extends LitElement {
         .footer,
         .content {
           background-color: var(--bgc);
+        }
+
+        .form-level-error {
+          margin: 0.4rem;
         }
 
         .content {

--- a/src/organisms/gv-schema-form/gv-schema-form.stories.js
+++ b/src/organisms/gv-schema-form/gv-schema-form.stories.js
@@ -84,6 +84,45 @@ const mixedValues = {
   multiselect: ['a', 'b', 'c'],
 };
 
+const rootOneOfSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  oneOf: [
+    {
+      title: 'OpenApi source from a Content Provider Resource ',
+      properties: { resourceName: { type: 'string', title: 'Resource name' } },
+      required: ['resourceName'],
+    },
+    {
+      title: 'OpenApi source from an JSON editor ',
+      properties: { sourceJson: { type: 'string', title: 'JSON' } },
+      required: ['sourceJson'],
+    },
+    {
+      title: 'OpenApi source from an YAML editor ',
+      properties: { sourceYaml: { type: 'string', title: 'YAML' } },
+      required: ['sourceYaml'],
+    },
+    {
+      title: 'OpenApi source from a URL',
+      properties: { sourceUrl: { type: 'string', title: 'URL' } },
+      required: ['sourceUrl'],
+    },
+  ],
+};
+
+export const RootOneOf = makeStory(conf, {
+  items: [
+    {
+      title: 'Root oneOf — surfaces validator failure as a banner',
+      schema: rootOneOfSchema,
+      values: {},
+      'has-footer': true,
+      'validate-on-render': true,
+    },
+  ],
+});
+
 export const Skeleton = makeStory(conf, {
   items: [
     {

--- a/src/organisms/gv-schema-form/gv-schema-form.test.js
+++ b/src/organisms/gv-schema-form/gv-schema-form.test.js
@@ -15,6 +15,13 @@
  */
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { Page, querySelector, since } from '../../../testing/lib/test-utils';
+import {
+  expectControlGuardsHoldWithRootOneOf,
+  expectNoThrowOnNonArrayErrors,
+  expectRootOneOfBanner,
+  rootOneOfSchema,
+  rootOneOfWithPropertiesSchema,
+} from '../../../testing/lib/schema-form-test-utils';
 import './gv-schema-form';
 import mixed from '../../../testing/resources/schemas/mixed.json';
 import fieldsDependencies from '../../../testing/resources/schemas/fields-dependencies.json';
@@ -596,6 +603,28 @@ describe('S C H E M A  F O R M', () => {
     expect(results.errors[0].message).toEqual(
       'A path or a content is <span class="error">required</span> - for JKS and PKCS#12 a password is also <span class="error">required</span>',
     );
+  });
+
+  test('should render a banner and not throw on root oneOf failures', async () => {
+    component.schema = rootOneOfSchema;
+    component.values = {};
+    component.touch = true;
+    await expectRootOneOfBanner(component);
+  });
+
+  test('should not crash when root oneOf coexists with rendered controls', async () => {
+    component.schema = rootOneOfWithPropertiesSchema;
+    component.values = {};
+    component.touch = true;
+    await expectControlGuardsHoldWithRootOneOf(component);
+  });
+
+  test('should not throw when errors is a non-array value', async () => {
+    // Use a minimal schema so the test doesn't churn the 21-control mixed tree.
+    component.schema = { type: 'object', properties: { foo: { type: 'string' } } };
+    component.values = {};
+    await component.updateComplete;
+    await expectNoThrowOnNonArrayErrors(component);
   });
 
   test('should validate with additional properties', () => {

--- a/testing/lib/schema-form-test-utils.js
+++ b/testing/lib/schema-form-test-utils.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@jest/globals';
+
+export const rootOneOfSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  oneOf: [
+    {
+      title: 'Source A ',
+      properties: { sourceA: { type: 'string' } },
+      required: ['sourceA'],
+    },
+    {
+      title: 'Source B',
+      properties: { sourceB: { type: 'string' } },
+      required: ['sourceB'],
+    },
+  ],
+};
+
+// Combines top-level properties (so gv-schema-form-control instances actually
+// render) with a root oneOf (so the validator emits an array-argument error
+// that hits the control's shouldUpdate forEach loop). This is the shape that
+// reproduces the production DOMException, so the control-level guards
+// (Array.isArray, typeof key string, CSS.escape) are actually exercised here.
+export const rootOneOfWithPropertiesSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  properties: {
+    basePath: { type: 'string', title: 'Base Path' },
+  },
+  oneOf: [
+    {
+      title: 'Source A ',
+      properties: { sourceA: { type: 'string', title: 'Source A' } },
+      required: ['sourceA'],
+    },
+    {
+      title: 'Source B',
+      properties: { sourceB: { type: 'string', title: 'Source B' } },
+      required: ['sourceB'],
+    },
+  ],
+};
+
+export async function expectControlGuardsHoldWithRootOneOf(component) {
+  let caught;
+  try {
+    component.validate();
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeUndefined();
+  await component.updateComplete;
+
+  const banner = component.shadowRoot.querySelector('.form-level-error');
+  expect(banner).not.toBeNull();
+  expect(banner.textContent).toContain('Select exactly one of');
+
+  // Top-level property still rendered as a control — proves the
+  // child shouldUpdate didn't crash on the array-argument error.
+  const controlElements = component.shadowRoot.querySelectorAll('gv-schema-form-control');
+  expect(controlElements.length).toBeGreaterThan(0);
+  const basePathControl = Array.from(controlElements).find((c) => c.id === 'basePath');
+  expect(basePathControl).not.toBeUndefined();
+}
+
+export async function expectNoThrowOnNonArrayErrors(component) {
+  const banner = () => component.shadowRoot.querySelector('.form-level-error');
+
+  let caught;
+  try {
+    component.errors = { not: 'an array' };
+    await component.updateComplete;
+    component.errors = null;
+    await component.updateComplete;
+    component.errors = undefined;
+    await component.updateComplete;
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeUndefined();
+  expect(banner()).toBeNull();
+}
+
+export async function expectRootOneOfBanner(component) {
+  let caught;
+  try {
+    component.validate();
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeUndefined();
+  await component.updateComplete;
+
+  expect(component.errors).toHaveLength(1);
+  expect(component.errors[0].name).toEqual('oneOf');
+  expect(Array.isArray(component.errors[0].argument)).toBe(true);
+
+  const banner = component.shadowRoot.querySelector('.form-level-error');
+  expect(banner).not.toBeNull();
+  expect(banner.textContent).toContain('Select exactly one of');
+  expect(banner.textContent).toContain('Source A');
+  expect(banner.textContent).toContain('Source B');
+  expect(banner.textContent).not.toContain('"Source');
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-11067

**Description**

Adding the OpenAPI Validation policy in the V2 policy studio renders the Settings section unreachable. The browser console throws:

```
DOMException: DocumentFragment.querySelector: '[id=""OpenApi source from a Content Provider Resource ","OpenApi source from an JSON editor ","OpenApi source from an YAML editor ","OpenApi source from a URL"-error"]' is not a valid selector
```

**Root cause**

`gv-schema-form-control` interpolates `error.argument` directly into a CSS attribute selector. For root `oneOf` / `anyOf` failures, the `jsonschema` validator returns `error.argument` as an array of `JSON.stringify(title)` entries. `Array.prototype.toString()` joins them with commas (embedded quotes survive), producing an invalid selector. The `DOMException` is thrown inside Lit's `shouldUpdate`, which aborts the host element's rendering — hence the blank Settings section.

**Fix**

- `gv-schema-form-control`:
  - Tighten the errors guard from `!= null` to `Array.isArray` so a non-array binding cannot reach the `forEach`.
  - Skip individual errors when the resolved key is not a string (e.g. an array argument from root `oneOf`/`anyOf`).
  - Use `CSS.escape` (with a jsdom-safe fallback) when building the `[id="<key>-error"]` selector.
- `gv-schema-form` and `gv-schema-form-group`: surface non-attachable root errors (`property === 'instance'` AND `Array.isArray(argument)`) as a form-level `gv-input-message` banner above the content, with a readable formatted message (`Select exactly one of: …`).
- Extract `getFormLevelErrors` / `formatFormLevelError` into `src/lib/schema-form.js` so both wrappers share the implementation.

Submit remains blocked while the form is invalid — `isValid()` still counts the underlying error, only the visual attachment changes.

**Tests / verification**

- Regression tests on both wrappers covering the root `oneOf` banner path and non-array `errors` assignments.
- New `RootOneOf` story under `Organisms/gv-schema-form` for visual replay.
- Manual storybook verification against the OAS Validation schema: pre-patch reproduces the original `DOMException`; post-patch the banner renders and submit stays disabled until a source is filled.

**Out of scope (follow-ups)**

- Nested `oneOf` failures (`error.property = 'instance.<field>'`) are still dropped; the original ticket is root-level only and the wrapper banner heuristic is intentionally scoped to root.
- The pre-existing `message.innerHTML = this.formatErrorMessage(error)` line in `gv-schema-form-control` is an XSS concern (Semgrep flagged) — separate ticket.
- `allOf` is not handled: `jsonschema` emits `allOf` errors with an object argument (`{id, length, valid}`), so a different surfacing strategy is needed; deferred.