### PR TITLE
ci(chromatic): pick first storybook url from chromatic output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       - keeper/exec:
           step-name: Running Chromatic
           command: |
-            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
+            SB_URL=$(npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*" | head -n 1)
             if [ -z "$SB_URL" ]
             then
               echo "Something bad happened when running Chromatic"


### PR DESCRIPTION
**Issue**

The `chromatic-deployment` workflow's "Edit Pull Request Description" step fails on PRs whose Storybook tree changes (new or modified stories). Symptom:

```
/tmp/.bash_env-…-build: line 8: https://<hash>-<id>.chromatic.com: No such file or directory
Exited with code exit status 1
```

**Root cause**

`.circleci/config.yml` (Running Chromatic step) captures the storybook URL via:

```bash
SB_URL=$(npx chromatic … | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
echo "export SB_URL=$SB_URL" >> $BASH_ENV
```

When the chromatic CLI prints the storybook URL line more than once (it does so on PRs with story changes — once mid-progress, once in the final summary), `grep -o` returns multiple matches. `SB_URL` becomes multi-line, and the `echo` then writes:

```
export SB_URL=https://first.chromatic.com
https://second.chromatic.com
```

The next step sources `$BASH_ENV`; bash treats line 2 as a command, looks for the URL as an executable, and exits 1.

**Fix**

Pipe `| head -n 1` after the second `grep -o` so SB_URL stays single-line.

**Verification**

The full chromatic-deployment workflow runs on this branch; CI green is the regression proof.