### PR TITLE
fix(gv-date-picker): statically import date-fns locales to fix runtime locale loading

### DIFF
--- a/src/atoms/gv-date-picker/gv-date-picker.js
+++ b/src/atoms/gv-date-picker/gv-date-picker.js
@@ -15,6 +15,9 @@
  */
 import '../gv-date-picker-calendar';
 import enUS from 'date-fns/locale/en-US';
+import cs from 'date-fns/locale/cs';
+import fr from 'date-fns/locale/fr';
+import it from 'date-fns/locale/it';
 import { format, getMonth, getYear, parse } from 'date-fns';
 import { classMap } from 'lit/directives/class-map.js';
 import { css, LitElement, html } from 'lit';
@@ -24,7 +27,10 @@ import { isInvalid } from '../../lib/date';
 import { until } from 'lit/directives/until.js';
 import { dispatchCustomEvent } from '../../lib/events';
 
-const locales = { en: enUS };
+// Locales are imported statically: a dynamic `date-fns/locale/${lang}` import is
+// only resolvable by webpack (magic comments) and breaks at runtime under
+// bundlers like esbuild that ship it to the browser as a bare specifier.
+const locales = { en: enUS, cs, fr, it };
 
 /**
  * Date Picker
@@ -290,24 +296,7 @@ export class GvDatePicker extends LitElement {
 
   async getLocale() {
     const lang = getLanguage();
-    if (!lang) {
-      return locales.en;
-    }
-    if (!locales[lang]) {
-      try {
-        const locale = await import(
-          // TODO: complete or improve the solution when managing a larger set of languages
-          /* webpackInclude: /(en|fr|cs)\/index\.js$/ */
-          /* webpackMode: "lazy-once" */
-          /* webpackChunkName: "date-fns-locale" */
-          `date-fns/locale/${lang}/index.js`
-        );
-        locales[lang] = locale.default;
-      } catch (e) {
-        console.error(`[Error] cannot load locale ${lang}`, e);
-      }
-    }
-    return locales[lang];
+    return locales[lang] || locales.en;
   }
 
   get dateFromPlaceholder() {

--- a/src/atoms/gv-date-picker/gv-date-picker.test.js
+++ b/src/atoms/gv-date-picker/gv-date-picker.test.js
@@ -15,6 +15,7 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
 import { Page, querySelector } from '../../../testing/lib/test-utils';
+import { setLanguage } from '../../lib/i18n';
 import './gv-date-picker';
 
 describe('D A T E P I C K E R', () => {
@@ -27,11 +28,40 @@ describe('D A T E P I C K E R', () => {
 
   afterEach(() => {
     page.clear();
+    setLanguage(undefined);
   });
 
   test('should create element', () => {
     expect(window.customElements.get('gv-date-picker')).toBeDefined();
     const component = querySelector('gv-date-picker');
     expect(component).toBeDefined();
+  });
+
+  describe('getLocale', () => {
+    test.each([
+      ['en', 'en-US'],
+      ['fr', 'fr'],
+      ['cs', 'cs'],
+      ['it', 'it'],
+    ])('should resolve the %s locale without dynamic import', async (lang, expectedCode) => {
+      setLanguage(lang);
+      const component = querySelector('gv-date-picker');
+      const locale = await component.getLocale();
+      expect(locale).toBeDefined();
+      expect(locale.code).toEqual(expectedCode);
+    });
+
+    test('should fall back to en-US for an unsupported language', async () => {
+      setLanguage('de');
+      const component = querySelector('gv-date-picker');
+      const locale = await component.getLocale();
+      expect(locale.code).toEqual('en-US');
+    });
+
+    test('should fall back to en-US when no language is set', async () => {
+      const component = querySelector('gv-date-picker');
+      const locale = await component.getLocale();
+      expect(locale.code).toEqual('en-US');
+    });
   });
 });


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14668

**Description**

  Fix date-picker locale loading at runtime (empty calendar for non-English browsers)                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  gv-date-picker loaded non-English date-fns locales via a template-literal dynamic import (date-fns/locale/${lang}/index.js) guarded by webpack magic comments. Consumers that bundle with esbuild (e.g. the APIM classic portal on Angular's application builder) ignore those comments and ship the raw import to the browser, which cannot resolve a bare specifier → Failed to resolve module specifier  'date-fns/locale/fr/index.js' → the picker's locale resolves to undefined and the calendar renders no selectable days. English was unaffected (separate static import).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                

**Changes**
                                                                                                                                                                                                                                                                                                                                                                                                                        
  - Statically import the supported locales (en-US, cs, fr, it — matching the portal's shipped languages; it was missing even from the old webpack webpackInclude whitelist) and resolve them from a plain map.                                                                                                                                                                                                                  
  - getLocale() now falls back to en-US for unknown/unset languages instead of returning undefined.                                                                                                                                                                                                                                                                                                                              
  - Added Jest regression tests: each supported locale resolves without any dynamic import; unknown or unset language falls back to en-US.                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  Bundler-agnostic (works identically under webpack and esbuild) and net-simpler: removes the dynamic-import/error-handling machinery entirely. Verified end-to-end against the APIM classic portal with browser locale fr — calendar renders and dates are selectable.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://5ffff84833d7150021078521-fxsymgxgdb.chromatic.com)
<!-- Storybook placeholder end -->
